### PR TITLE
Review and normalization of the javadoc

### DIFF
--- a/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
-import static ch.powerunit.extensions.exceptions.Constants.OPERATION_CANT_BE_NULL;
+import static ch.powerunit.extensions.exceptions.Constants.CONSUMER_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.BiConsumer;
@@ -31,7 +31,6 @@ import java.util.function.Supplier;
  * result and may throw exception. Unlike most other functional interfaces,
  * {@code BiConsumerWithException} is expected to operate via side-effects.
  *
- * @author borettim
  * @see BiConsumer
  * @param <T>
  *            the type of the first argument to the operation
@@ -59,11 +58,12 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 
 	/**
 	 * Converts this {@code BiConsumerWithException} to a {@code BiConsumer} that
-	 * convert exception to {@code RuntimeException}.
+	 * wraps exception into {@code RuntimeException}.
 	 *
 	 * @return the unchecked operation
 	 * @see #unchecked(BiConsumerWithException)
 	 * @see #unchecked(BiConsumerWithException, Function)
+	 * @see BiConsumer
 	 */
 	@Override
 	default BiConsumer<T, U> uncheck() {
@@ -72,10 +72,11 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 
 	/**
 	 * Converts this {@code BiConsumerWithException} to a <i>lifted</i>
-	 * {@code BiConsumer} ignoring exception.
+	 * {@code BiConsumer} that ignore exception.
 	 *
 	 * @return the operation that ignore error
 	 * @see #ignored(BiConsumerWithException)
+	 * @see BiConsumer
 	 */
 	@Override
 	default BiConsumer<T, U> ignore() {
@@ -91,12 +92,10 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 *
 	 * @param after
 	 *            the operation to perform after this operation
-	 * @return a composed {@code Consumer} that performs in sequence this operation
-	 *         followed by the {@code after} operation
+	 * @return a composed {@code BiConsumerWithException} that performs in sequence
+	 *         this operation followed by the {@code after} operation
 	 * @throws NullPointerException
 	 *             if {@code after} is null
-	 *
-	 *
 	 * @see BiConsumer#andThen(BiConsumer)
 	 */
 	default BiConsumerWithException<T, U, E> andThen(BiConsumerWithException<? super T, ? super U, ? extends E> after) {
@@ -108,16 +107,17 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Returns an operation that always throw exception.
+	 * Returns an {@code BiConsumerWithException} that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the first argument to the operation
 	 * @param <U>
-	 *            the type of the second input object to the operation
+	 *            the type of the second argument to the operation
 	 * @param <E>
-	 *            the type of the exception
+	 *            the type of the potential exception of the operation
+	 *
 	 * @return an operation that always throw exception
 	 */
 	static <T, U, E extends Exception> BiConsumerWithException<T, U, E> failing(Supplier<E> exceptionBuilder) {
@@ -127,53 +127,85 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiConsumerWithException} to a {@code Consumer} that convert
+	 * Converts a {@code BiConsumerWithException} to a {@code BiConsumer} that wraps
 	 * exception to {@code RuntimeException}.
+	 * <p>
+	 * For example :
 	 *
-	 * @param operation
+	 * <pre>
+	 * ConsumerWithException&lt;String, IOException&gt; consumerThrowingException = ...;
+	 *
+	 * Consumer&lt;String&gt; consumerThrowingRuntimeException =
+	 *   ConsumerWithException.unchecked(consumerThrowingException);
+	 *
+	 * Stream.of(...).forEach(consumerThrowingRuntimeException)
+	 * </pre>
+	 * 
+	 * In case of exception inside {@code consumerThrowingRuntimeException} an
+	 * instance of {@code WrappedException} with the original exception as cause
+	 * will be thrown.
+	 *
+	 * @param consumer
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the first argument to the operation
 	 * @param <U>
-	 *            the type of the second input object to the operation
+	 *            the type of the second argument to the operation
 	 * @param <E>
-	 *            the type of the potential exception
+	 *            the type of the potential exception of the operation
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(BiConsumerWithException, Function)
 	 */
-	static <T, U, E extends Exception> BiConsumer<T, U> unchecked(BiConsumerWithException<T, U, E> operation) {
-		return requireNonNull(operation, OPERATION_CANT_BE_NULL).uncheck();
+	static <T, U, E extends Exception> BiConsumer<T, U> unchecked(BiConsumerWithException<T, U, E> consumer) {
+		return requireNonNull(consumer, CONSUMER_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code BiConsumerWithException} to a {@code BiConsumer} that
-	 * convert exception to {@code RuntimeException} by using the provided mapping
-	 * function.
+	 * Converts a {@code BiConsumerWithException} to a {@code BiConsumer} that wraps
+	 * exception to {@code RuntimeException} by using the provided mapping function.
+	 * 
+	 * <p>
+	 * For example :
 	 *
-	 * @param operation
+	 * <pre>
+	 * ConsumerWithException&lt;String, IOException&gt; consumerThrowingException = ...;
+	 *
+	 * Consumer&lt;String&gt; consumerThrowingRuntimeException =
+	 *   ConsumerWithException.unchecked(
+	 *     consumerThrowingException,
+	 *     IllegalArgumentException::new);
+	 *
+	 * Stream.of(...).forEach(consumerThrowingRuntimeException)
+	 * </pre>
+	 * 
+	 * In case of exception inside {@code consumerThrowingRuntimeException} an
+	 * instance of {@code IllegalArgumentException} with the original exception as
+	 * cause will be thrown.
+	 *
+	 * @param consumer
 	 *            the be unchecked
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the first argument to the operation
 	 * @param <U>
-	 *            the type of the second input object to the operation
+	 *            the type of the second argument to the operation
 	 * @param <E>
-	 *            the type of the potential exception
+	 *            the type of the potential exception of the operation
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(BiConsumerWithException)
 	 */
-	static <T, U, E extends Exception> BiConsumer<T, U> unchecked(BiConsumerWithException<T, U, E> operation,
+	static <T, U, E extends Exception> BiConsumer<T, U> unchecked(BiConsumerWithException<T, U, E> consumer,
 			Function<Exception, RuntimeException> exceptionMapper) {
-		requireNonNull(operation, OPERATION_CANT_BE_NULL);
+		requireNonNull(consumer, CONSUMER_CANT_BE_NULL);
 		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
 		return new BiConsumerWithException<T, U, E>() {
 
 			@Override
 			public void accept(T t, U u) throws E {
-				operation.accept(t, u);
+				consumer.accept(t, u);
 			}
 
 			@Override
@@ -186,63 +218,63 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 
 	/**
 	 * Converts a {@code BiConsumerWithException} to a lifted {@code BiConsumer}
-	 * returning {@code null} in case of exception.
+	 * ignoring exception.
 	 *
-	 * @param operation
+	 * @param consumer
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the first argument to the operation
 	 * @param <U>
-	 *            the type of the second input object to the operation
+	 *            the type of the second argument to the operation
 	 * @param <E>
-	 *            the type of the potential exception
+	 *            the type of the potential exception of the operation
 	 * @return the lifted operation
 	 * @see #lift()
 	 */
-	static <T, U, E extends Exception> BiConsumer<T, U> lifted(BiConsumerWithException<T, U, E> operation) {
-		return requireNonNull(operation, OPERATION_CANT_BE_NULL).lift();
+	static <T, U, E extends Exception> BiConsumer<T, U> lifted(BiConsumerWithException<T, U, E> consumer) {
+		return requireNonNull(consumer, CONSUMER_CANT_BE_NULL).lift();
 	}
 
 	/**
 	 * Converts a {@code BiConsumerWithException} to a lifted {@code BiConsumer}
-	 * returning {@code null} in case of exception.
+	 * ignoring exception.
 	 *
-	 * @param operation
+	 * @param consumer
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the first argument to the operation
 	 * @param <U>
-	 *            the type of the second input object to the operation
+	 *            the type of the second argument to the operation
 	 * @param <E>
-	 *            the type of the potential exception
+	 *            the type of the potential exception of the operation
 	 * @return the lifted operation
 	 * @see #ignore()
 	 */
-	static <T, U, E extends Exception> BiConsumer<T, U> ignored(BiConsumerWithException<T, U, E> operation) {
-		return requireNonNull(operation, OPERATION_CANT_BE_NULL).ignore();
+	static <T, U, E extends Exception> BiConsumer<T, U> ignored(BiConsumerWithException<T, U, E> consumer) {
+		return requireNonNull(consumer, CONSUMER_CANT_BE_NULL).ignore();
 	}
 
 	/**
 	 * Converts a {@code BiConsumerWithException} to a
 	 * {@code BiFunctionWithException} returning {@code null}.
 	 *
-	 * @param operation
+	 * @param consumer
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the first argument to the operation
 	 * @param <U>
-	 *            the type of the second input object to the operation
+	 *            the type of the second argument to the operation
 	 * @param <R>
-	 *            the type of the return value
+	 *            the type of the return value of the function
 	 * @param <E>
-	 *            the type of the potential exception
+	 *            the type of the potential exception of the operation
 	 * @return the function
 	 */
 	static <T, U, R, E extends Exception> BiFunctionWithException<T, U, R, E> asBiFunction(
-			BiConsumerWithException<T, U, E> operation) {
-		requireNonNull(operation, OPERATION_CANT_BE_NULL);
+			BiConsumerWithException<T, U, E> consumer) {
+		requireNonNull(consumer, CONSUMER_CANT_BE_NULL);
 		return (t, u) -> {
-			operation.accept(t, u);
+			consumer.accept(t, u);
 			return null;
 		};
 	}

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
@@ -141,7 +141,7 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 *
 	 * myMap.forEach(consumerThrowingRuntimeException);
 	 * </pre>
-	 * 
+	 *
 	 * In case of exception inside {@code consumerThrowingRuntimeException} an
 	 * instance of {@code WrappedException} with the original exception as cause
 	 * will be thrown.
@@ -167,7 +167,7 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	/**
 	 * Converts a {@code BiConsumerWithException} to a {@code BiConsumer} that wraps
 	 * exception to {@code RuntimeException} by using the provided mapping function.
-	 * 
+	 *
 	 * <p>
 	 * For example :
 	 *
@@ -181,7 +181,7 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 *
 	 * myMap.forEach(consumerThrowingRuntimeException)
 	 * </pre>
-	 * 
+	 *
 	 * In case of exception inside {@code consumerThrowingRuntimeException} an
 	 * instance of {@code IllegalArgumentException} with the original exception as
 	 * cause will be thrown.
@@ -235,7 +235,7 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 *
 	 * myMap.forEach(consumerThrowingRuntimeException);
 	 * </pre>
-	 * 
+	 *
 	 * In case of exception inside {@code consumerThrowingRuntimeException} the
 	 * exception will be ignored.
 	 *
@@ -270,7 +270,7 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 *
 	 * myMap.forEach(consumerThrowingRuntimeException);
 	 * </pre>
-	 * 
+	 *
 	 * In case of exception inside {@code consumerThrowingRuntimeException} the
 	 * exception will be ignored.
 	 *

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
@@ -223,6 +223,20 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	/**
 	 * Converts a {@code BiConsumerWithException} to a lifted {@code BiConsumer}
 	 * ignoring exception.
+	 * <p>
+	 * For example :
+	 *
+	 * <pre>
+	 * BiConsumerWithException&lt;String, String, IOException&gt; consumerThrowingException = ...;
+	 *
+	 * BiConsumer&lt;String, String&gt; consumerThrowingRuntimeException =
+	 *   ConsumerWithException.lifted(consumerThrowingException);
+	 *
+	 * myMap.forEach(consumerThrowingRuntimeException);
+	 * </pre>
+	 * 
+	 * In case of exception inside {@code consumerThrowingRuntimeException} the
+	 * exception will be ignored.
 	 *
 	 * @param consumer
 	 *            to be lifted
@@ -244,6 +258,20 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	/**
 	 * Converts a {@code BiConsumerWithException} to a lifted {@code BiConsumer}
 	 * ignoring exception.
+	 * <p>
+	 * For example :
+	 *
+	 * <pre>
+	 * BiConsumerWithException&lt;String, String, IOException&gt; consumerThrowingException = ...;
+	 *
+	 * BiConsumer&lt;String, String&gt; consumerThrowingRuntimeException =
+	 *   ConsumerWithException.ignored(consumerThrowingException);
+	 *
+	 * myMap.forEach(consumerThrowingRuntimeException);
+	 * </pre>
+	 * 
+	 * In case of exception inside {@code consumerThrowingRuntimeException} the
+	 * exception will be ignored.
 	 *
 	 * @param consumer
 	 *            to be lifted
@@ -267,7 +295,7 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 * {@code BiFunctionWithException} returning {@code null}.
 	 *
 	 * @param consumer
-	 *            to be lifted
+	 *            to be converter
 	 * @param <T>
 	 *            the type of the first argument to the operation
 	 * @param <U>

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
@@ -133,12 +133,12 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 * For example :
 	 *
 	 * <pre>
-	 * ConsumerWithException&lt;String, IOException&gt; consumerThrowingException = ...;
+	 * BiConsumerWithException&lt;String, String, IOException&gt; consumerThrowingException = ...;
 	 *
-	 * Consumer&lt;String&gt; consumerThrowingRuntimeException =
+	 * BiConsumer&lt;String, String&gt; consumerThrowingRuntimeException =
 	 *   ConsumerWithException.unchecked(consumerThrowingException);
 	 *
-	 * Stream.of(...).forEach(consumerThrowingRuntimeException)
+	 * myMap.forEach(consumerThrowingRuntimeException);
 	 * </pre>
 	 * 
 	 * In case of exception inside {@code consumerThrowingRuntimeException} an
@@ -169,14 +169,14 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 * For example :
 	 *
 	 * <pre>
-	 * ConsumerWithException&lt;String, IOException&gt; consumerThrowingException = ...;
+	 * BiConsumerWithException&lt;String, String, IOException&gt; consumerThrowingException = ...;
 	 *
-	 * Consumer&lt;String&gt; consumerThrowingRuntimeException =
+	 * BiConsumer&lt;String, String&gt; consumerThrowingRuntimeException =
 	 *   ConsumerWithException.unchecked(
 	 *     consumerThrowingException,
 	 *     IllegalArgumentException::new);
 	 *
-	 * Stream.of(...).forEach(consumerThrowingRuntimeException)
+	 * myMap.forEach(consumerThrowingRuntimeException)
 	 * </pre>
 	 * 
 	 * In case of exception inside {@code consumerThrowingRuntimeException} an

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
@@ -20,6 +20,7 @@
 package ch.powerunit.extensions.exceptions;
 
 import static ch.powerunit.extensions.exceptions.Constants.CONSUMER_CANT_BE_NULL;
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.BiConsumer;
@@ -107,7 +108,7 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Returns an {@code BiConsumerWithException} that always throw exception.
+	 * Returns a {@code BiConsumerWithException} that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
@@ -204,7 +205,7 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	static <T, U, E extends Exception> BiConsumer<T, U> unchecked(BiConsumerWithException<T, U, E> consumer,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(consumer, CONSUMER_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new BiConsumerWithException<T, U, E>() {
 
 			@Override

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
  * Represents an operation that accepts two input arguments and returns no
  * result and may throw exception. Unlike most other functional interfaces,
  * {@code BiConsumerWithException} is expected to operate via side-effects.
- * 
+ *
  * <h3>General contract</h3>
  * <ul>
  * <li><b>{@link #accept(Object, Object) void accept(T t,U u) throws

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
@@ -31,6 +31,15 @@ import java.util.function.Supplier;
  * Represents an operation that accepts two input arguments and returns no
  * result and may throw exception. Unlike most other functional interfaces,
  * {@code BiConsumerWithException} is expected to operate via side-effects.
+ * 
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #accept(Object, Object) void accept(T t,U u) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code Biconsumer<T,U>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code Biconsumer<T,U>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code Biconsumer<T,U>}</li>
+ * </ul>
  *
  * @see BiConsumer
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiConsumerWithException.java
@@ -156,6 +156,8 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(BiConsumerWithException, Function)
+	 * @throws NullPointerException
+	 *             if consumer is null
 	 */
 	static <T, U, E extends Exception> BiConsumer<T, U> unchecked(BiConsumerWithException<T, U, E> consumer) {
 		return requireNonNull(consumer, CONSUMER_CANT_BE_NULL).uncheck();
@@ -196,6 +198,8 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(BiConsumerWithException)
+	 * @throws NullPointerException
+	 *             if consumer or exceptionMapper is null
 	 */
 	static <T, U, E extends Exception> BiConsumer<T, U> unchecked(BiConsumerWithException<T, U, E> consumer,
 			Function<Exception, RuntimeException> exceptionMapper) {
@@ -230,6 +234,8 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 *            the type of the potential exception of the operation
 	 * @return the lifted operation
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if consumer is null
 	 */
 	static <T, U, E extends Exception> BiConsumer<T, U> lifted(BiConsumerWithException<T, U, E> consumer) {
 		return requireNonNull(consumer, CONSUMER_CANT_BE_NULL).lift();
@@ -249,6 +255,8 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 *            the type of the potential exception of the operation
 	 * @return the lifted operation
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if consumer is null
 	 */
 	static <T, U, E extends Exception> BiConsumer<T, U> ignored(BiConsumerWithException<T, U, E> consumer) {
 		return requireNonNull(consumer, CONSUMER_CANT_BE_NULL).ignore();
@@ -269,6 +277,8 @@ public interface BiConsumerWithException<T, U, E extends Exception>
 	 * @param <E>
 	 *            the type of the potential exception of the operation
 	 * @return the function
+	 * @throws NullPointerException
+	 *             if consumer is null
 	 */
 	static <T, U, R, E extends Exception> BiFunctionWithException<T, U, R, E> asBiFunction(
 			BiConsumerWithException<T, U, E> consumer) {

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
@@ -135,7 +135,7 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 *         the {@code after} function
 	 * @throws NullPointerException
 	 *             if after is null
-	 * 
+	 *
 	 * @see BiFunction#andThen(Function)
 	 */
 	default <V> BiFunctionWithException<T, U, V, E> andThen(

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
@@ -34,6 +34,16 @@ import java.util.function.Supplier;
  * produces a result. This is the two-arity specialization of
  * {@link FunctionWithException}.
  *
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #apply(Object, Object) R apply(T t, U u) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code BiFunction<T,U,R>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a
+ * {@code BiFunction<T,U,<Optional<R>>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code BiFunction<T,U,R>}</li>
+ * </ul>
+ * 
  * @see BiFunction
  * @param <T>
  *            the type of the first argument to the function

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -29,15 +30,15 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents a function that accepts two arguments, may throw exception and
- * produces a result.
+ * Represents a function that accepts two arguments, may thrown exception and
+ * produces a result. This is the two-arity specialization of
+ * {@link FunctionWithException}.
  *
- * @author borettim
  * @see BiFunction
  * @param <T>
- *            the type of the first input to the function
+ *            the type of the first argument to the function
  * @param <U>
- *            the type of the second input to the function
+ *            the type of the second argument to the function
  * @param <R>
  *            the type of the result of the function
  * @param <E>
@@ -63,11 +64,12 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 
 	/**
 	 * Converts this {@code BiFunctionWithException} to a {@code BiFunction} that
-	 * convert exception to {@code RuntimeException}.
+	 * wraps exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked function
 	 * @see #unchecked(BiFunctionWithException)
 	 * @see #unchecked(BiFunctionWithException, Function)
+	 * @see BiFunction
 	 */
 	@Override
 	default BiFunction<T, U, R> uncheck() {
@@ -81,6 +83,7 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 *
 	 * @return the lifted function
 	 * @see #lifted(BiFunctionWithException)
+	 * @see BiFunction
 	 */
 	@Override
 	default BiFunction<T, U, Optional<R>> lift() {
@@ -94,6 +97,7 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 *
 	 * @return the function that ignore error
 	 * @see #ignored(BiFunctionWithException)
+	 * @see BiFunction
 	 */
 	@Override
 	default BiFunction<T, U, R> ignore() {
@@ -102,30 +106,36 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 
 	/**
 	 * Convert this {@code BiFunctionWithException} to a lifted {@code BiFunction}
-	 * return {@code CompletionStage} as return value.
+	 * that uses {@code CompletionStage} as return value.
 	 *
 	 * @return the lifted function
 	 * @see #staged(BiFunctionWithException)
+	 * @see BiFunction
+	 * @see CompletionStage
 	 */
 	default BiFunction<T, U, CompletionStage<R>> stage() {
 		return (t, u) -> ObjectReturnExceptionHandlerSupport.staged(() -> apply(t, u));
 	}
 
 	/**
-	 * Returns a composed function that first applies this function to its input,
-	 * and then applies the {@code after} function to the result. If evaluation of
-	 * either function throws an exception, it is relayed to the caller of the
-	 * composed function.
+	 * Returns a composed {@code FunctionWithException} that first applies this
+	 * {@code FunctionWithException} to its input, and then applies the
+	 * {@code after} {@code FunctionWithException} to the result. If evaluation of
+	 * either {@code FunctionWithException} throws an exception, it is relayed to
+	 * the caller of the composed function.
 	 *
 	 * @param <V>
-	 *            the type of output of the {@code after} function, and of the
-	 *            composed function
+	 *            the type of output of the {@code after}
+	 *            {@code FunctionWithException}, and of the composed
+	 *            {@code FunctionWithException}
 	 * @param after
-	 *            the function to apply after this function is applied
+	 *            the function to apply after this {@code FunctionWithException} is
+	 *            applied
 	 * @return a composed function that first applies this function and then applies
 	 *         the {@code after} function
 	 * @throws NullPointerException
 	 *             if after is null
+	 * 
 	 * @see BiFunction#andThen(Function)
 	 */
 	default <V> BiFunctionWithException<T, U, V, E> andThen(
@@ -135,16 +145,16 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	}
 
 	/**
-	 * Returns a function that always throw exception.
+	 * Returns a {@code FunctionWithException} that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the exception
 	 * @return a function that always throw exception
@@ -162,16 +172,18 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 * @param function
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(BiFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, R, E extends Exception> BiFunction<T, U, R> unchecked(BiFunctionWithException<T, U, R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -187,21 +199,23 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(BiFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <T, U, R, E extends Exception> BiFunction<T, U, R> unchecked(BiFunctionWithException<T, U, R, E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new BiFunctionWithException<T, U, R, E>() {
 
 			@Override
@@ -224,15 +238,17 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, R, E extends Exception> BiFunction<T, U, Optional<R>> lifted(
 			BiFunctionWithException<T, U, R, E> function) {
@@ -246,15 +262,17 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, R, E extends Exception> BiFunction<T, U, R> ignored(BiFunctionWithException<T, U, R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();
@@ -267,15 +285,17 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #stage()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, R, E extends Exception> BiFunction<T, U, CompletionStage<R>> staged(
 			BiFunctionWithException<T, U, R, E> function) {

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
@@ -168,6 +168,16 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	/**
 	 * Converts a {@code BiFunctionWithException} to a {@code BiFunction} that
 	 * convert exception to {@code RuntimeException}.
+	 * <p>
+	 * For example :
+	 * 
+	 * <pre>
+	 * BiFunction&lt;String, String, String&gt; biFunctionThrowingRuntimeException = BiFunctionWithException
+	 * 		.unchecked(biFouctionThrowingException);
+	 * </pre>
+	 * 
+	 * Will generate a {@code BiFunction} throwing {@code RuntimeException} in case
+	 * of error.
 	 *
 	 * @param function
 	 *            to be unchecked
@@ -193,6 +203,16 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 * Converts a {@code BiFunctionWithException} to a {@code BiFunction} that
 	 * convert exception to {@code RuntimeException} by using the provided mapping
 	 * function.
+	 * <p>
+	 * For example :
+	 * 
+	 * <pre>
+	 * BiFunction&lt;String, String, String&gt; functionThrowingRuntimeException = BiFunctionWithException
+	 * 		.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+	 * </pre>
+	 * 
+	 * Will generate a {@code BiFunction} throwing {@code IllegalArgumentException}
+	 * in case of error.
 	 *
 	 * @param function
 	 *            the be unchecked

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
@@ -43,7 +43,7 @@ import java.util.function.Supplier;
  * {@code BiFunction<T,U,<Optional<R>>}</li>
  * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code BiFunction<T,U,R>}</li>
  * </ul>
- * 
+ *
  * @see BiFunction
  * @param <T>
  *            the type of the first argument to the function

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiFunctionWithException.java
@@ -170,12 +170,12 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 * convert exception to {@code RuntimeException}.
 	 * <p>
 	 * For example :
-	 * 
+	 *
 	 * <pre>
 	 * BiFunction&lt;String, String, String&gt; biFunctionThrowingRuntimeException = BiFunctionWithException
 	 * 		.unchecked(biFouctionThrowingException);
 	 * </pre>
-	 * 
+	 *
 	 * Will generate a {@code BiFunction} throwing {@code RuntimeException} in case
 	 * of error.
 	 *
@@ -205,12 +205,12 @@ public interface BiFunctionWithException<T, U, R, E extends Exception>
 	 * function.
 	 * <p>
 	 * For example :
-	 * 
+	 *
 	 * <pre>
 	 * BiFunction&lt;String, String, String&gt; functionThrowingRuntimeException = BiFunctionWithException
 	 * 		.unchecked(fonctionThrowingException, IllegalArgumentException::new);
 	 * </pre>
-	 * 
+	 *
 	 * Will generate a {@code BiFunction} throwing {@code IllegalArgumentException}
 	 * in case of error.
 	 *

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiPredicateWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiPredicateWithException.java
@@ -32,6 +32,14 @@ import java.util.function.Supplier;
  * Represents a predicate (boolean-valued function) of two arguments that may
  * throw exception. This is the two-arity specialization of
  * {@link PredicateWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #test(Object, Object) boolean test(T t, U u) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code BiPredicate<T, U>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code BiPredicate<T, U>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code BiPredicate<T, U>}</li>
+ * </ul>
  *
  *
  * @see BiPredicate

--- a/src/main/java/ch/powerunit/extensions/exceptions/BiPredicateWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BiPredicateWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.PREDICATE_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -28,13 +29,14 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
- * Represents a predicate (boolean-valued function) of one argument and may
- * throw an exception.
+ * Represents a predicate (boolean-valued function) of two arguments that may
+ * throw exception. This is the two-arity specialization of
+ * {@link PredicateWithException}.
  *
- * @author borettim
- * @see Predicate
+ *
+ * @see BiPredicate
  * @param <T>
- *            the type of the first input to the predicate
+ *            the type of the first argument to the predicate
  * @param <U>
  *            the type of the second argument the predicate
  * @param <E>
@@ -50,8 +52,8 @@ public interface BiPredicateWithException<T, U, E extends Exception>
 	 * @param t
 	 *            the first input argument
 	 * @param u
-	 *            the first second argument
-	 * @return {@code true} if the input argument matches the predicate, otherwise
+	 *            the second input argument
+	 * @return {@code true} if the input arguments match the predicate, otherwise
 	 *         {@code false}
 	 * @throws E
 	 *             any exception
@@ -113,9 +115,9 @@ public interface BiPredicateWithException<T, U, E extends Exception>
 	 * @param predicate
 	 *            to be negate
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the predicate
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the predicate
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the negated predicate
@@ -156,9 +158,9 @@ public interface BiPredicateWithException<T, U, E extends Exception>
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the predicate
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the predicate
 	 * @param <E>
 	 *            the type of the exception
 	 * @return a predicate that always throw exception
@@ -171,19 +173,21 @@ public interface BiPredicateWithException<T, U, E extends Exception>
 
 	/**
 	 * Converts a {@code BiPredicateWithException} to a {@code BiPredicate} that
-	 * convert exception to {@code RuntimeException}.
+	 * wraps to {@code RuntimeException}.
 	 *
 	 * @param predicate
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the predicate
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the predicate
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked predicate
 	 * @see #uncheck()
 	 * @see #unchecked(BiPredicateWithException, Function)
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <T, U, E extends Exception> BiPredicate<T, U> unchecked(BiPredicateWithException<T, U, E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).uncheck();
@@ -191,27 +195,28 @@ public interface BiPredicateWithException<T, U, E extends Exception>
 
 	/**
 	 * Converts a {@code BiPredicateWithException} to a {@code BiPredicate} that
-	 * convert exception to {@code RuntimeException} by using the provided mapping
-	 * function.
+	 * wraps to {@code RuntimeException} by using the provided mapping function.
 	 *
 	 * @param predicate
 	 *            the be unchecked
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the predicate
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the predicate
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked predicate
 	 * @see #uncheck()
 	 * @see #unchecked(BiPredicateWithException)
+	 * @throws NullPointerException
+	 *             if predicate or exceptionMapper is null
 	 */
 	static <T, U, E extends Exception> BiPredicate<T, U> unchecked(BiPredicateWithException<T, U, E> predicate,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(predicate, PREDICATE_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new BiPredicateWithException<T, U, E>() {
 
 			@Override
@@ -229,18 +234,20 @@ public interface BiPredicateWithException<T, U, E extends Exception>
 
 	/**
 	 * Converts a {@code BiPredicateWithException} to a lifted {@code BiPredicate}
-	 * returning {@code null} in case of exception.
+	 * returning {@code false} in case of exception.
 	 *
 	 * @param predicate
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the predicate
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the predicate
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the lifted function
+	 * @return the lifted predicate
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <T, U, E extends Exception> BiPredicate<T, U> lifted(BiPredicateWithException<T, U, E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).lift();
@@ -248,18 +255,20 @@ public interface BiPredicateWithException<T, U, E extends Exception>
 
 	/**
 	 * Converts a {@code BiPredicateWithException} to a lifted {@code BiPredicate}
-	 * returning {@code null} in case of exception.
+	 * returning {@code false} in case of exception.
 	 *
 	 * @param predicate
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the predicate
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the predicate
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the lifted function
+	 * @return the lifted predicate
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <T, U, E extends Exception> BiPredicate<T, U> ignored(BiPredicateWithException<T, U, E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/BinaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BinaryOperatorWithException.java
@@ -19,24 +19,29 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents an operation upon two operands of the same type, may throw
- * exception and producing a result of the same type as the operands. This is a
- * specialization of {@code FunctionWithException} for the case where the
- * operand and result are of the same type.
+ * Represents an operation upon two operands of the same type, that may throw
+ * exception, producing a result of the same type as the operands. This is a
+ * specialization of {@link BiFunctionWithException} for the case where the
+ * operands and the result are all of the same type.
+ * <p>
+ * As this interface must return the same type of the input, a lifted version
+ * which returns {@code Optional} is not possible.
  *
- * @author borettim
- * @see FunctionWithException
+ * @see BiFunctionWithException
  * @see BinaryOperator
  * @param <T>
- *            the type of the input and output to the function
+ *            the type of the operands and result of the operator
  * @param <E>
  *            the type of the potential exception of the function
  */
@@ -74,7 +79,7 @@ public interface BinaryOperatorWithException<T, E extends Exception> extends BiF
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the input and output object to the function
+	 *            the type of the operands and result of the operator
 	 * @param <E>
 	 *            the type of the exception
 	 * @return a function that always throw exception
@@ -92,12 +97,14 @@ public interface BinaryOperatorWithException<T, E extends Exception> extends BiF
 	 * @param function
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the operands and result of the operator
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(BinaryOperatorWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> BinaryOperator<T> unchecked(BinaryOperatorWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -113,17 +120,19 @@ public interface BinaryOperatorWithException<T, E extends Exception> extends BiF
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the input and output object to the function
+	 *            the type of the operands and result of the operator
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(BinaryOperatorWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <T, E extends Exception> BinaryOperator<T> unchecked(BinaryOperatorWithException<T, E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new BinaryOperatorWithException<T, E>() {
 
 			@Override
@@ -140,17 +149,38 @@ public interface BinaryOperatorWithException<T, E extends Exception> extends BiF
 	}
 
 	/**
-	 * Converts a {@code BinaryOperatorWithException} to a lifted
-	 * {@code BinaryOperator} returning {@code null} in case of exception.
+	 * Converts a {@code BinaryOperatorWithException} to a lifted {@code Function}
+	 * returning an optional in case of exception.
 	 *
 	 * @param function
-	 *            to be lifted
+	 *            the be unchecked
 	 * @param <T>
-	 *            the type of the input and output object to the function
+	 *            the type of the operands and result of the operator
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
+	 */
+	static <T, E extends Exception> BiFunction<T, T, Optional<T>> lifted(BinaryOperatorWithException<T, E> function) {
+		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
+	}
+
+	/**
+	 * Converts a {@code BinaryOperatorWithException} to a lifted
+	 * {@code BinaryOperator} returning {@code null} in case of exception.
+	 *
+	 * @param function
+	 *            the be unchecked
+	 * @param <T>
+	 *            the type of the operands and result of the operator
+	 * @param <E>
+	 *            the type of the potential exception
+	 * @return the lifted function
+	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> BinaryOperator<T> ignored(BinaryOperatorWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/BinaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BinaryOperatorWithException.java
@@ -37,6 +37,15 @@ import java.util.function.Supplier;
  * <p>
  * As this interface must return the same type of the input, a lifted version
  * which returns {@code Optional} is not possible.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #apply(Object, Object) T apply(T t, T u) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code BinaryOperator<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a
+ * {@code BiFunction<T,T,<Optional<T>>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code BinaryOperator<T>}</li>
+ * </ul>
  *
  * @see BiFunctionWithException
  * @see BinaryOperator

--- a/src/main/java/ch/powerunit/extensions/exceptions/BooleanSupplierWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BooleanSupplierWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
  * Represents a supplier of {@code boolean}-valued results which may throw
  * exception. This is the {@code boolean}-producing primitive specialization of
  * {@link SupplierWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #getAsBoolean() boolean getAsBoolean() throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code BooleanSupplier}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code BooleanSupplier}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code BooleanSupplier}</li>
+ * </ul>
  *
  * @see BooleanSupplier
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/BooleanSupplierWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/BooleanSupplierWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.SUPPLIER_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,12 +28,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents a supplier of {@code boolean}-valued results that may throw
+ * Represents a supplier of {@code boolean}-valued results which may throw
  * exception. This is the {@code boolean}-producing primitive specialization of
- * {@link Supplier}.
+ * {@link SupplierWithException}.
  *
- * @author borettim
- * @see Supplier
+ * @see BooleanSupplier
  * @param <E>
  *            the type of the potential exception of the operation
  */
@@ -79,15 +79,17 @@ public interface BooleanSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code BooleanSupplierWithException} to a {@code BooleanSupplier}
-	 * that convert exception to {@code RuntimeException}. o
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param supplier
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked supplier
 	 * @see #uncheck()
 	 * @see #unchecked(BooleanSupplierWithException, Function)
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> BooleanSupplier unchecked(BooleanSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).uncheck();
@@ -95,7 +97,7 @@ public interface BooleanSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code BooleanSupplierWithException} to a {@code BooleanSupplier}
-	 * that convert exception to {@code RuntimeException} by using the provided
+	 * that wraps exception to {@code RuntimeException} by using the provided
 	 * mapping function.
 	 *
 	 * @param supplier
@@ -104,14 +106,16 @@ public interface BooleanSupplierWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked supplier
 	 * @see #uncheck()
 	 * @see #unchecked(BooleanSupplierWithException)
+	 * @throws NullPointerException
+	 *             if supplier and exceptionMapper is null
 	 */
 	static <E extends Exception> BooleanSupplier unchecked(BooleanSupplierWithException<E> supplier,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(supplier, SUPPLIER_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new BooleanSupplierWithException<E>() {
 
 			@Override
@@ -137,6 +141,8 @@ public interface BooleanSupplierWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted supplier
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> BooleanSupplier lifted(BooleanSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).lift();
@@ -152,6 +158,8 @@ public interface BooleanSupplierWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted supplier
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> BooleanSupplier ignored(BooleanSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/Constants.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/Constants.java
@@ -34,6 +34,8 @@ final class Constants {
 	public static final String PREDICATE_CANT_BE_NULL = "predicate can't be null";
 
 	public static final String CONSUMER_CANT_BE_NULL = "consumer can't be null";
+	
+	public static final String EXCEPTIONMAPPER_CANT_BE_NULL = "exceptionMapper can't be null";
 
 	private Constants() {
 	}

--- a/src/main/java/ch/powerunit/extensions/exceptions/Constants.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/Constants.java
@@ -34,7 +34,7 @@ final class Constants {
 	public static final String PREDICATE_CANT_BE_NULL = "predicate can't be null";
 
 	public static final String CONSUMER_CANT_BE_NULL = "consumer can't be null";
-	
+
 	public static final String EXCEPTIONMAPPER_CANT_BE_NULL = "exceptionMapper can't be null";
 
 	private Constants() {

--- a/src/main/java/ch/powerunit/extensions/exceptions/Constants.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/Constants.java
@@ -33,6 +33,8 @@ final class Constants {
 
 	public static final String PREDICATE_CANT_BE_NULL = "predicate can't be null";
 
+	public static final String CONSUMER_CANT_BE_NULL = "consumer can't be null";
+
 	private Constants() {
 	}
 

--- a/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
@@ -21,14 +21,11 @@ package ch.powerunit.extensions.exceptions;
 
 import static ch.powerunit.extensions.exceptions.Constants.CONSUMER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
-
 import static java.util.Objects.requireNonNull;
 
-import java.io.IOException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 /**
  * Represents an operation that accepts a single input argument, may thrown
@@ -127,16 +124,16 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * exception to {@code RuntimeException}.
 	 * <p>
 	 * For example :
-	 * 
+	 *
 	 * <pre>
 	 * ConsumerWithException&lt;String, IOException&gt; consumerThrowingException = ...;
-	 * 
-	 * Consumer&lt;String&gt; consumerThrowingRuntimeException = 
+	 *
+	 * Consumer&lt;String&gt; consumerThrowingRuntimeException =
 	 *   ConsumerWithException.unchecked(consumerThrowingException);
-	 * 
+	 *
 	 * Stream....forEach(consumerThrowingRuntimeException);
 	 * </pre>
-	 * 
+	 *
 	 * In case of exception inside {@code consumerThrowingRuntimeException} an
 	 * instance of {@code WrappedException} with the original exception as cause
 	 * will be thrown.
@@ -162,19 +159,19 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * exception to {@code RuntimeException} by using the provided mapping function.
 	 * <p>
 	 * For example :
-	 * 
+	 *
 	 * <pre>
 	 * ConsumerWithException&lt;String, IOException&gt; consumerThrowingException = ...;
-	 * 
-	 * Consumer&lt;String&gt; consumerThrowingRuntimeException = 
+	 *
+	 * Consumer&lt;String&gt; consumerThrowingRuntimeException =
 	 *   ConsumerWithException.unchecked(
 	 *     consumerThrowingException,
 	 *     IllegalArgumentException::new
 	 *   );
-	 * 
+	 *
 	 * Stream....forEach(consumerThrowingRuntimeException);
 	 * </pre>
-	 * 
+	 *
 	 * In case of exception inside {@code consumerThrowingRuntimeException} an
 	 * instance of {@code IllegalArgumentException} with the original exception as
 	 * cause will be thrown.

--- a/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
@@ -108,7 +108,7 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the input object to the operation
+	 *            the type of the input to the operation
 	 * @param <E>
 	 *            the type of the exception
 	 * @return an operation that always throw exception
@@ -141,7 +141,7 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * @param consumer
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the input object to the operation
+	 *            the type of the input to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
@@ -181,7 +181,7 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the input object to the operation
+	 *            the type of the input to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
@@ -216,7 +216,7 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * @param consumer
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the input object to the operation
+	 *            the type of the input to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted operation
@@ -235,7 +235,7 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * @param consumer
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the input object to the operation
+	 *            the type of the input to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted operation
@@ -254,7 +254,7 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * @param consumer
 	 *            to be converted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the input to the operation
 	 * @param <R>
 	 *            the type of the return value
 	 * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
@@ -103,7 +103,7 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	}
 
 	/**
-	 * Returns a {@code Consumer} that always throw exception.
+	 * Returns a {@code ConsumerWithException} that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception

--- a/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
@@ -19,19 +19,22 @@
  */
 package ch.powerunit.extensions.exceptions;
 
-import static ch.powerunit.extensions.exceptions.Constants.OPERATION_CANT_BE_NULL;
+import static ch.powerunit.extensions.exceptions.Constants.CONSUMER_CANT_BE_NULL;
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
+
 import static java.util.Objects.requireNonNull;
 
+import java.io.IOException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
- * Represents an operation that accepts a single input argument and returns no
- * result and may throw exception. Unlike most other functional interfaces,
- * {@code Consumer} is expected to operate via side-effects.
+ * Represents an operation that accepts a single input argument, may thrown
+ * exception and returns no result. Unlike most other functional interfaces,
+ * {@code ConsumerWithException} is expected to operate via side-effects.
  *
- * @author borettim
  * @see Consumer
  * @param <T>
  *            the type of the input to the operation
@@ -53,12 +56,13 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	void accept(T t) throws E;
 
 	/**
-	 * Converts this {@code ConsumerWithException} to a {@code Consumer} that
-	 * convert exception to {@code RuntimeException}.
+	 * Converts this {@code ConsumerWithException} to a {@code Consumer} that wraps
+	 * exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked operation
 	 * @see #unchecked(ConsumerWithException)
 	 * @see #unchecked(ConsumerWithException, Function)
+	 * @see Consumer
 	 */
 	@Override
 	default Consumer<T> uncheck() {
@@ -67,10 +71,11 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 
 	/**
 	 * Converts this {@code ConsumerWithException} to a <i>lifted</i>
-	 * {@code Consumer} ignoring exception.
+	 * {@code Consumer} that ignore exception.
 	 *
 	 * @return the operation that ignore error
 	 * @see #ignored(ConsumerWithException)
+	 * @see Consumer
 	 */
 	@Override
 	default Consumer<T> ignore() {
@@ -86,12 +91,10 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 *
 	 * @param after
 	 *            the operation to perform after this operation
-	 * @return a composed {@code Consumer} that performs in sequence this operation
-	 *         followed by the {@code after} operation
+	 * @return a composed {@code ConsumerWithException} that performs in sequence
+	 *         this operation followed by the {@code after} operation
 	 * @throws NullPointerException
 	 *             if {@code after} is null
-	 *
-	 *
 	 * @see Consumer#andThen(Consumer)
 	 */
 	default ConsumerWithException<T, E> andThen(ConsumerWithException<? super T, ? extends E> after) {
@@ -103,7 +106,7 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	}
 
 	/**
-	 * Returns an operation that always throw exception.
+	 * Returns a {@code Consumer} that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
@@ -120,10 +123,25 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	}
 
 	/**
-	 * Converts a {@code ConsumerWithException} to a {@code Consumer} that convert
+	 * Converts a {@code ConsumerWithException} to a {@code Consumer} that wraps
 	 * exception to {@code RuntimeException}.
+	 * <p>
+	 * For example :
+	 * 
+	 * <pre>
+	 * ConsumerWithException&lt;String, IOException&gt; consumerThrowingException = ...;
+	 * 
+	 * Consumer&lt;String&gt; consumerThrowingRuntimeException = 
+	 *   ConsumerWithException.unchecked(consumerThrowingException);
+	 * 
+	 * Stream....forEach(consumerThrowingRuntimeException);
+	 * </pre>
+	 * 
+	 * In case of exception inside {@code consumerThrowingRuntimeException} an
+	 * instance of {@code WrappedException} with the original exception as cause
+	 * will be thrown.
 	 *
-	 * @param operation
+	 * @param consumer
 	 *            to be unchecked
 	 * @param <T>
 	 *            the type of the input object to the operation
@@ -132,16 +150,36 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(ConsumerWithException, Function)
+	 * @throws NullPointerException
+	 *             if consumer is null
 	 */
-	static <T, E extends Exception> Consumer<T> unchecked(ConsumerWithException<T, E> operation) {
-		return requireNonNull(operation, OPERATION_CANT_BE_NULL).uncheck();
+	static <T, E extends Exception> Consumer<T> unchecked(ConsumerWithException<T, E> consumer) {
+		return requireNonNull(consumer, CONSUMER_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code ConsumerWithException} to a {@code Consumer} that convert
+	 * Converts a {@code ConsumerWithException} to a {@code Consumer} that wraps
 	 * exception to {@code RuntimeException} by using the provided mapping function.
+	 * <p>
+	 * For example :
+	 * 
+	 * <pre>
+	 * ConsumerWithException&lt;String, IOException&gt; consumerThrowingException = ...;
+	 * 
+	 * Consumer&lt;String&gt; consumerThrowingRuntimeException = 
+	 *   ConsumerWithException.unchecked(
+	 *     consumerThrowingException,
+	 *     IllegalArgumentException::new
+	 *   );
+	 * 
+	 * Stream....forEach(consumerThrowingRuntimeException);
+	 * </pre>
+	 * 
+	 * In case of exception inside {@code consumerThrowingRuntimeException} an
+	 * instance of {@code IllegalArgumentException} with the original exception as
+	 * cause will be thrown.
 	 *
-	 * @param operation
+	 * @param consumer
 	 *            the be unchecked
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
@@ -152,16 +190,18 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(ConsumerWithException)
+	 * @throws NullPointerException
+	 *             if consumer or exceptionMapper is null
 	 */
-	static <T, E extends Exception> Consumer<T> unchecked(ConsumerWithException<T, E> operation,
+	static <T, E extends Exception> Consumer<T> unchecked(ConsumerWithException<T, E> consumer,
 			Function<Exception, RuntimeException> exceptionMapper) {
-		requireNonNull(operation, OPERATION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(consumer, CONSUMER_CANT_BE_NULL);
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new ConsumerWithException<T, E>() {
 
 			@Override
 			public void accept(T t) throws E {
-				operation.accept(t);
+				consumer.accept(t);
 			}
 
 			@Override
@@ -174,9 +214,9 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 
 	/**
 	 * Converts a {@code ConsumerWithException} to a lifted {@code Consumer}
-	 * returning {@code null} in case of exception.
+	 * ignoring exception.
 	 *
-	 * @param operation
+	 * @param consumer
 	 *            to be lifted
 	 * @param <T>
 	 *            the type of the input object to the operation
@@ -184,16 +224,18 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if consumer is null
 	 */
-	static <T, E extends Exception> Consumer<T> lifted(ConsumerWithException<T, E> operation) {
-		return requireNonNull(operation, OPERATION_CANT_BE_NULL).lift();
+	static <T, E extends Exception> Consumer<T> lifted(ConsumerWithException<T, E> consumer) {
+		return requireNonNull(consumer, CONSUMER_CANT_BE_NULL).lift();
 	}
 
 	/**
 	 * Converts a {@code ConsumerWithException} to a lifted {@code Consumer}
-	 * returning {@code null} in case of exception.
+	 * ignoring exception.
 	 *
-	 * @param operation
+	 * @param consumer
 	 *            to be lifted
 	 * @param <T>
 	 *            the type of the input object to the operation
@@ -201,16 +243,18 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if consumer is null
 	 */
-	static <T, E extends Exception> Consumer<T> ignored(ConsumerWithException<T, E> operation) {
-		return requireNonNull(operation, OPERATION_CANT_BE_NULL).ignore();
+	static <T, E extends Exception> Consumer<T> ignored(ConsumerWithException<T, E> consumer) {
+		return requireNonNull(consumer, CONSUMER_CANT_BE_NULL).ignore();
 	}
 
 	/**
 	 * Converts a {@code ConsumerWithException} to a {@code FunctionWithException}
 	 * returning {@code null}.
 	 *
-	 * @param operation
+	 * @param consumer
 	 *            to be lifted
 	 * @param <T>
 	 *            the type of the first input object to the operation
@@ -219,12 +263,13 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the function
+	 * @throws NullPointerException
+	 *             if consumer is null
 	 */
-	static <T, R, E extends Exception> FunctionWithException<T, R, E> asFunction(
-			ConsumerWithException<T, E> operation) {
-		requireNonNull(operation, OPERATION_CANT_BE_NULL);
+	static <T, R, E extends Exception> FunctionWithException<T, R, E> asFunction(ConsumerWithException<T, E> consumer) {
+		requireNonNull(consumer, CONSUMER_CANT_BE_NULL);
 		return t -> {
-			operation.accept(t);
+			consumer.accept(t);
 			return null;
 		};
 	}

--- a/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
  * Represents an operation that accepts a single input argument, may thrown
  * exception and returns no result. Unlike most other functional interfaces,
  * {@code ConsumerWithException} is expected to operate via side-effects.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #accept(Object) void accept(T t) throws E}</b>&nbsp;-&nbsp;The
+ * functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code Consumer<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code Consumer<T>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code Consumer<T>}</li>
+ * </ul>
  *
  * @see Consumer
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ConsumerWithException.java
@@ -252,7 +252,7 @@ public interface ConsumerWithException<T, E extends Exception> extends NoReturnE
 	 * returning {@code null}.
 	 *
 	 * @param consumer
-	 *            to be lifted
+	 *            to be converted
 	 * @param <T>
 	 *            the type of the first input object to the operation
 	 * @param <R>

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleBinaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleBinaryOperatorWithException.java
@@ -32,6 +32,14 @@ import java.util.function.Supplier;
  * exception and producing a {@code double}-valued result. This is the primitive
  * type specialization of {@link BinaryOperatorWithException} for
  * {@code double}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsDouble(double, double) double applyAsDouble(double
+ * left, double right) throws E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code DoubleBinaryOperator}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code DoubleBinaryOperator}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code DoubleBinaryOperator}</li>
+ * </ul>
  *
  * @see DoubleBinaryOperator
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleBinaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleBinaryOperatorWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -83,16 +84,18 @@ public interface DoubleBinaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleBinaryOperatorException} to a
-	 * {@code DoubleBinaryOperator} that convert exception to
+	 * {@code DoubleBinaryOperator} that wraps exception to
 	 * {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleBinaryOperatorWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleBinaryOperator unchecked(DoubleBinaryOperatorWithException<E> function) {
 		return function.uncheck();
@@ -100,8 +103,8 @@ public interface DoubleBinaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleBinaryOperatorWithException} to a
-	 * {@code DoubleBinaryOperator} that convert exception to
-	 * {@code RuntimeException} by using the provided mapping function.
+	 * {@code DoubleBinaryOperator} that wraps exception to {@code RuntimeException}
+	 * by using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
@@ -109,14 +112,16 @@ public interface DoubleBinaryOperatorWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleBinaryOperatorWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <E extends Exception> DoubleBinaryOperator unchecked(DoubleBinaryOperatorWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new DoubleBinaryOperatorWithException<E>() {
 
 			@Override
@@ -134,7 +139,8 @@ public interface DoubleBinaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleBinaryOperatorWithException} to a lifted
-	 * {@code DoubleBinaryOperator} using {@code Optional} as return value.
+	 * {@code DoubleBinaryOperator} with {@code 0} as return value in case of
+	 * exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -142,6 +148,8 @@ public interface DoubleBinaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleBinaryOperator lifted(DoubleBinaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
@@ -149,7 +157,8 @@ public interface DoubleBinaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleBinaryOperatorWithException} to a lifted
-	 * {@code DoubleBinaryOperator} returning {@code null} in case of exception.
+	 * {@code DoubleBinaryOperator} with {@code 0} as return value in case of
+	 * exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -157,6 +166,8 @@ public interface DoubleBinaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleBinaryOperator ignored(DoubleBinaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleConsumerWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.OPERATION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,11 +28,12 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents an operation that accepts a single input argument and returns no
- * result and may throw exception. Unlike most other functional interfaces,
- * {@code Consumer} is expected to operate via side-effects.
+ * Represents an operation that accepts a single {@code double}-valued argument,
+ * may throw exception and returns no result. This is the primitive type
+ * specialization of {@link ConsumerWithException} for {@code double}. Unlike
+ * most other functional interfaces, {@code DoubleConsumerWithException} is
+ * expected to operate via side-effects.
  *
- * @author borettim
  * @see DoubleConsumer
  * @param <E>
  *            the type of the potential exception of the operation
@@ -43,17 +45,17 @@ public interface DoubleConsumerWithException<E extends Exception>
 	/**
 	 * Performs this operation on the given argument.
 	 *
-	 * @param t
+	 * @param value
 	 *            the input argument
 	 * @throws E
 	 *             any exception
 	 * @see DoubleConsumer#accept(double)
 	 */
-	void accept(double t) throws E;
+	void accept(double value) throws E;
 
 	/**
 	 * Converts this {@code DoubleConsumerWithException} to a {@code DoubleConsumer}
-	 * that convert exception to {@code RuntimeException}.
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked operation
 	 * @see #unchecked(DoubleConsumerWithException)
@@ -90,7 +92,6 @@ public interface DoubleConsumerWithException<E extends Exception>
 	 * @throws NullPointerException
 	 *             if {@code after} is null
 	 *
-	 *
 	 * @see DoubleConsumer#andThen(DoubleConsumer)
 	 */
 	default DoubleConsumerWithException<E> andThen(DoubleConsumerWithException<? extends E> after) {
@@ -118,15 +119,17 @@ public interface DoubleConsumerWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleConsumerWithException} to a {@code DoubleConsumer}
-	 * that convert exception to {@code RuntimeException}.
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param operation
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleConsumerWithException, Function)
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> DoubleConsumer unchecked(DoubleConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).uncheck();
@@ -134,7 +137,7 @@ public interface DoubleConsumerWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleConsumerWithException} to a {@code DoubleConsumer}
-	 * that convert exception to {@code RuntimeException} by using the provided
+	 * that wraps exception to {@code RuntimeException} by using the provided
 	 * mapping function.
 	 *
 	 * @param operation
@@ -143,19 +146,21 @@ public interface DoubleConsumerWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleConsumerWithException)
+	 * @throws NullPointerException
+	 *             if operation or exceptionMapper is null
 	 */
 	static <E extends Exception> DoubleConsumer unchecked(DoubleConsumerWithException<E> operation,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(operation, OPERATION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new DoubleConsumerWithException<E>() {
 
 			@Override
-			public void accept(double t) throws E {
-				operation.accept(t);
+			public void accept(double value) throws E {
+				operation.accept(value);
 			}
 
 			@Override
@@ -176,6 +181,8 @@ public interface DoubleConsumerWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> DoubleConsumer lifted(DoubleConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).lift();
@@ -191,6 +198,8 @@ public interface DoubleConsumerWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> DoubleConsumer ignored(DoubleConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).ignore();
@@ -205,6 +214,8 @@ public interface DoubleConsumerWithException<E extends Exception>
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the function
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> ConsumerWithException<Double, E> asConsumer(DoubleConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL)::accept;

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleConsumerWithException.java
@@ -33,6 +33,14 @@ import java.util.function.Supplier;
  * specialization of {@link ConsumerWithException} for {@code double}. Unlike
  * most other functional interfaces, {@code DoubleConsumerWithException} is
  * expected to operate via side-effects.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #accept(double) void accept(double value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code DoubleConsumer}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code DoubleConsumer}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code DoubleConsumer}</li>
+ * </ul>
  *
  * @see DoubleConsumer
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleConsumerWithException.java
@@ -173,7 +173,7 @@ public interface DoubleConsumerWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleConsumerWithException} to a lifted
-	 * {@code DoubleConsumer} returning {@code null} in case of exception.
+	 * {@code DoubleConsumer} ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
@@ -190,7 +190,7 @@ public interface DoubleConsumerWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleConsumerWithException} to a lifted
-	 * {@code DoubleConsumer} returning {@code null} in case of exception.
+	 * {@code DoubleConsumer} ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
@@ -207,13 +207,13 @@ public interface DoubleConsumerWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleConsumerWithException} to a
-	 * {@code ConsumerWithException} returning {@code null}.
+	 * {@code ConsumerWithException}.
 	 *
 	 * @param operation
-	 *            to be lifted
+	 *            to be converted
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the function
+	 * @return the consumer
 	 * @throws NullPointerException
 	 *             if operation is null
 	 */

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleFunctionWithException.java
@@ -33,6 +33,14 @@ import java.util.function.Supplier;
  * Represents a function that accepts a double-valued argument, may throw
  * exception and produces a result. This is the {@code double}-consuming
  * primitive specialization for {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #apply(double) R apply(double value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code DoubleFunction<R>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code DoubleFunction<Optional<R>>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code DoubleFunction<R>}</li>
+ * </ul>
  *
  * @see DoubleFunction
  * @param <R>

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -29,10 +30,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents a function that accepts one argument, may throw exception and
- * produces a result.
+ * Represents a function that accepts a double-valued argument and produces a
+ * result. This is the {@code double}-consuming primitive specialization for
+ * {@link FunctionWithException}.
  *
- * @author borettim
  * @see DoubleFunction
  * @param <R>
  *            the type of the result of the function
@@ -41,23 +42,23 @@ import java.util.function.Supplier;
  */
 @FunctionalInterface
 public interface DoubleFunctionWithException<R, E extends Exception>
-		extends ObjectReturnExceptionHandlerSupport<DoubleFunction<R>, Function<Double, Optional<R>>, R> {
+		extends ObjectReturnExceptionHandlerSupport<DoubleFunction<R>, DoubleFunction<Optional<R>>, R> {
 
 	/**
 	 * Applies this function to the given argument.
 	 *
-	 * @param t
+	 * @param value
 	 *            the function argument
 	 * @return the function result
 	 * @throws E
 	 *             any exception
 	 * @see DoubleFunction#apply(double)
 	 */
-	R apply(double t) throws E;
+	R apply(double value) throws E;
 
 	/**
 	 * Converts this {@code DoubleFunctionWithException} to a {@code DoubleFunction}
-	 * that convert exception to {@code RuntimeException}.
+	 * that wraps to {@code RuntimeException}.
 	 *
 	 * @return the unchecked function
 	 * @see #unchecked(DoubleFunctionWithException)
@@ -76,7 +77,7 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 	 * @see #lifted(DoubleFunctionWithException)
 	 */
 	@Override
-	default Function<Double, Optional<R>> lift() {
+	default DoubleFunction<Optional<R>> lift() {
 		return t -> ObjectReturnExceptionHandlerSupport.unchecked(() -> Optional.ofNullable(apply(t)),
 				notThrowingHandler());
 	}
@@ -95,7 +96,7 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 
 	/**
 	 * Convert this {@code DoubleFunctionWithException} to a lifted
-	 * {@code DoubleFunction} return {@code CompletionStage} as return value.
+	 * {@code DoubleFunction} returning {@code CompletionStage} as return value.
 	 *
 	 * @return the lifted function
 	 * @see #staged(DoubleFunctionWithException)
@@ -110,7 +111,7 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the exception
 	 * @return a function that always throw exception
@@ -123,17 +124,19 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 
 	/**
 	 * Converts a {@code FunctionWithException} to a {@code DoubleFunction} that
-	 * convert exception to {@code RuntimeException}.
+	 * wraps to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <R, E extends Exception> DoubleFunction<R> unchecked(DoubleFunctionWithException<R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -141,30 +144,32 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleFunctionWithException} to a {@code DoubleFunction}
-	 * that convert exception to {@code RuntimeException} by using the provided
-	 * mapping function.
+	 * that wraps to {@code RuntimeException} by using the provided mapping
+	 * function.
 	 *
 	 * @param function
 	 *            the be unchecked
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <R, E extends Exception> DoubleFunction<R> unchecked(DoubleFunctionWithException<R, E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new DoubleFunctionWithException<R, E>() {
 
 			@Override
-			public R apply(double t) throws E {
-				return function.apply(t);
+			public R apply(double value) throws E {
+				return function.apply(value);
 			}
 
 			@Override
@@ -182,13 +187,15 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
-	static <R, E extends Exception> Function<Double, Optional<R>> lifted(DoubleFunctionWithException<R, E> function) {
+	static <R, E extends Exception> DoubleFunction<Optional<R>> lifted(DoubleFunctionWithException<R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
 	}
 
@@ -199,11 +206,13 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <R, E extends Exception> DoubleFunction<R> ignored(DoubleFunctionWithException<R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();
@@ -216,11 +225,13 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #stage()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <R, E extends Exception> DoubleFunction<CompletionStage<R>> staged(
 			DoubleFunctionWithException<R, E> function) {

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleFunctionWithException.java
@@ -30,9 +30,9 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents a function that accepts a double-valued argument and produces a
- * result. This is the {@code double}-consuming primitive specialization for
- * {@link FunctionWithException}.
+ * Represents a function that accepts a double-valued argument, may throw
+ * exception and produces a result. This is the {@code double}-consuming
+ * primitive specialization for {@link FunctionWithException}.
  *
  * @see DoubleFunction
  * @param <R>
@@ -71,7 +71,7 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 
 	/**
 	 * Converts this {@code DoubleFunctionWithException} to a lifted
-	 * {@code Function} using {@code Optional} as return value.
+	 * {@code DoubleFunction} using {@code Optional} as return value.
 	 *
 	 * @return the lifted function
 	 * @see #lifted(DoubleFunctionWithException)
@@ -123,8 +123,8 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code FunctionWithException} to a {@code DoubleFunction} that
-	 * wraps to {@code RuntimeException}.
+	 * Converts a {@code DoubleFunctionWithException} to a {@code DoubleFunction}
+	 * that wraps to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
@@ -181,8 +181,8 @@ public interface DoubleFunctionWithException<R, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code DoubleFunctionWithException} to a lifted {@code Function}
-	 * using {@code Optional} as return value.
+	 * Converts a {@code DoubleFunctionWithException} to a lifted
+	 * {@code DoubleFunction} using {@code Optional} as return value.
 	 *
 	 * @param function
 	 *            to be lifted

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoublePredicateWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoublePredicateWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.PREDICATE_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,10 +28,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents a predicate (boolean-valued function) of one argument and may
- * throw an exception.
+ * Represents a predicate (boolean-valued function) of one {@code double}-valued
+ * argument that may throw exception. This is the {@code double}-consuming
+ * primitive type specialization of {@link PredicateWithException}.
  *
- * @author borettim
  * @see DoublePredicate
  * @param <E>
  *            the type of the potential exception of the function
@@ -42,7 +43,7 @@ public interface DoublePredicateWithException<E extends Exception>
 	/**
 	 * Evaluates this predicate on the given argument.
 	 *
-	 * @param t
+	 * @param value
 	 *            the input argument
 	 * @return {@code true} if the input argument matches the predicate, otherwise
 	 *         {@code false}
@@ -50,7 +51,7 @@ public interface DoublePredicateWithException<E extends Exception>
 	 *             any exception
 	 * @see DoublePredicate#test(double)
 	 */
-	boolean test(double t) throws E;
+	boolean test(double value) throws E;
 
 	@Override
 	default DoublePredicate uncheckOrIgnore(boolean uncheck) {
@@ -156,22 +157,24 @@ public interface DoublePredicateWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoublePredicateWithException} to a {@code DoublePredicate}
-	 * that convert exception to {@code RuntimeException}.
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param predicate
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked predicate
 	 * @see #uncheck()
 	 * @see #unchecked(DoublePredicateWithException, Function)
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <E extends Exception> DoublePredicate unchecked(DoublePredicateWithException<E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code PredicateWithException} to a {@code Predicate} that convert
+	 * Converts a {@code PredicateWithException} to a {@code Predicate} that wraps
 	 * exception to {@code RuntimeException} by using the provided mapping function.
 	 *
 	 * @param predicate
@@ -180,19 +183,21 @@ public interface DoublePredicateWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked predicate
 	 * @see #uncheck()
 	 * @see #unchecked(DoublePredicateWithException)
+	 * @throws NullPointerException
+	 *             if predicate or exceptionMapper is null
 	 */
 	static <E extends Exception> DoublePredicate unchecked(DoublePredicateWithException<E> predicate,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(predicate, PREDICATE_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new DoublePredicateWithException<E>() {
 
 			@Override
-			public boolean test(double t) throws E {
-				return predicate.test(t);
+			public boolean test(double value) throws E {
+				return predicate.test(value);
 			}
 
 			@Override
@@ -205,14 +210,16 @@ public interface DoublePredicateWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoublePredicateWithException} to a lifted
-	 * {@code DoublePredicate} returning {@code null} in case of exception.
+	 * {@code DoublePredicate} returning {@code false} in case of exception.
 	 *
 	 * @param predicate
 	 *            to be lifted
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the lifted function
+	 * @return the lifted predicate
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <E extends Exception> DoublePredicate lifted(DoublePredicateWithException<E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).lift();
@@ -220,14 +227,16 @@ public interface DoublePredicateWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoublePredicateWithException} to a lifted
-	 * {@code DoublePredicate} returning {@code null} in case of exception.
+	 * {@code DoublePredicate} returning {@code false} in case of exception.
 	 *
 	 * @param predicate
 	 *            to be lifted
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the lifted function
+	 * @return the lifted predicate
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <E extends Exception> DoublePredicate ignored(DoublePredicateWithException<E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoublePredicateWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoublePredicateWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
  * Represents a predicate (boolean-valued function) of one {@code double}-valued
  * argument that may throw exception. This is the {@code double}-consuming
  * primitive type specialization of {@link PredicateWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #test(double) boolean test(double value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code DoublePredicate}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code DoublePredicate}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code DoublePredicate}</li>
+ * </ul>
  *
  * @see DoublePredicate
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleSupplierWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleSupplierWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.SUPPLIER_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,12 +28,14 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents a supplier of {@code double}-valued results that may throw
+ * Represents a supplier of {@code double}-valued results and may throw
  * exception. This is the {@code double}-producing primitive specialization of
- * {@link Supplier}.
+ * {@link SupplierWithException}.
+ * <p>
+ * There is no requirement that a distinct result be returned each time the
+ * supplier is invoked.
  *
- * @author borettim
- * @see Supplier
+ * @see DoubleSupplier
  * @param <E>
  *            the type of the potential exception of the operation
  */
@@ -45,7 +48,7 @@ public interface DoubleSupplierWithException<E extends Exception>
 	 *
 	 * @throws E
 	 *             any exception
-	 * @return a boolean
+	 * @return a result
 	 * @see DoubleSupplier#getAsDouble()
 	 */
 	double getAsDouble() throws E;
@@ -79,15 +82,17 @@ public interface DoubleSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleSupplierWithException} to a {@code DoubleSupplier}
-	 * that convert exception to {@code RuntimeException}. o
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param supplier
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked supplier
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleSupplierWithException, Function)
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> DoubleSupplier unchecked(DoubleSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).uncheck();
@@ -95,7 +100,7 @@ public interface DoubleSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleSupplierWithException} to a {@code DoubleSupplier}
-	 * that convert exception to {@code RuntimeException} by using the provided
+	 * that wraps exception to {@code RuntimeException} by using the provided
 	 * mapping function.
 	 *
 	 * @param supplier
@@ -104,14 +109,16 @@ public interface DoubleSupplierWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked supplier
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleSupplierWithException)
+	 * @throws NullPointerException
+	 *             if supplier or exceptionMapper is null
 	 */
 	static <E extends Exception> DoubleSupplier unchecked(DoubleSupplierWithException<E> supplier,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(supplier, SUPPLIER_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new DoubleSupplierWithException<E>() {
 
 			@Override
@@ -129,7 +136,7 @@ public interface DoubleSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleSupplierWithException} to a lifted
-	 * {@code DoubleSupplier} returning {@code null} in case of exception.
+	 * {@code DoubleSupplier} returning {@code 0} in case of exception.
 	 *
 	 * @param supplier
 	 *            to be lifted
@@ -137,6 +144,8 @@ public interface DoubleSupplierWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted supplier
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> DoubleSupplier lifted(DoubleSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).lift();
@@ -144,7 +153,7 @@ public interface DoubleSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleSupplierWithException} to a lifted
-	 * {@code DoubleSupplier} returning {@code null} in case of exception.
+	 * {@code DoubleSupplier} returning {@code 0} in case of exception.
 	 *
 	 * @param supplier
 	 *            to be lifted
@@ -152,6 +161,8 @@ public interface DoubleSupplierWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted supplier
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> DoubleSupplier ignored(DoubleSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleSupplierWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleSupplierWithException.java
@@ -34,6 +34,14 @@ import java.util.function.Supplier;
  * <p>
  * There is no requirement that a distinct result be returned each time the
  * supplier is invoked.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #getAsDouble() double getAsDouble() throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code DoubleSupplier}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code DoubleSupplier}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code DoubleSupplier}</li>
+ * </ul>
  *
  * @see DoubleSupplier
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleToIntFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleToIntFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,10 +28,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents a predicate (boolean-valued function) of one argument and may
- * throw an exception.
+ * Represents a function that accepts a double-valued argument, may throw
+ * exception and produces an int-valued result. This is the
+ * {@code double}-to-{@code int} primitive specialization for
+ * {@link FunctionWithException}.
  *
- * @author borettim
  * @see DoubleToIntFunction
  * @param <E>
  *            the type of the potential exception of the function
@@ -40,16 +42,16 @@ public interface DoubleToIntFunctionWithException<E extends Exception>
 		extends PrimitiveReturnExceptionHandlerSupport<DoubleToIntFunction> {
 
 	/**
-	 * Evaluates this predicate on the given argument.
+	 * Applies this function to the given argument.
 	 *
-	 * @param t
-	 *            the input argument
-	 * @return the result
+	 * @param value
+	 *            the function argument
+	 * @return the function result
 	 * @throws E
 	 *             any exception
 	 * @see DoubleToIntFunction#applyAsInt(double)
 	 */
-	int applyAsInt(double t) throws E;
+	int applyAsInt(double value) throws E;
 
 	@Override
 	default DoubleToIntFunction uncheckOrIgnore(boolean uncheck) {
@@ -64,13 +66,13 @@ public interface DoubleToIntFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <E extends Exception> DoubleToIntFunctionWithException<E> failing(Supplier<E> exceptionBuilder) {
 		return t -> {
@@ -80,16 +82,17 @@ public interface DoubleToIntFunctionWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleToIntFunctionWithException} to a
-	 * {@code DoubleToIntFunction} that convert exception to
-	 * {@code RuntimeException}.
+	 * {@code DoubleToIntFunction} that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleToIntFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleToIntFunction unchecked(DoubleToIntFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -97,8 +100,8 @@ public interface DoubleToIntFunctionWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleToIntFunctionWithException} to a
-	 * {@code DoubleToIntFunction} that convert exception to
-	 * {@code RuntimeException} by using the provided mapping function.
+	 * {@code DoubleToIntFunction} that wraps exception to {@code RuntimeException}
+	 * by using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
@@ -109,16 +112,18 @@ public interface DoubleToIntFunctionWithException<E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleToIntFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <E extends Exception> DoubleToIntFunction unchecked(DoubleToIntFunctionWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new DoubleToIntFunctionWithException<E>() {
 
 			@Override
-			public int applyAsInt(double t) throws E {
-				return function.applyAsInt(t);
+			public int applyAsInt(double value) throws E {
+				return function.applyAsInt(value);
 			}
 
 			@Override
@@ -131,7 +136,7 @@ public interface DoubleToIntFunctionWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code DoubleToIntFunction} returning {@code null} in case of exception.
+	 * {@code DoubleToIntFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -139,6 +144,8 @@ public interface DoubleToIntFunctionWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleToIntFunction lifted(DoubleToIntFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
@@ -146,7 +153,7 @@ public interface DoubleToIntFunctionWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code DoubleToIntFunction} returning {@code null} in case of exception.
+	 * {@code DoubleToIntFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -154,6 +161,8 @@ public interface DoubleToIntFunctionWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleToIntFunction ignored(DoubleToIntFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleToIntFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleToIntFunctionWithException.java
@@ -32,6 +32,14 @@ import java.util.function.Supplier;
  * exception and produces an int-valued result. This is the
  * {@code double}-to-{@code int} primitive specialization for
  * {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsInt(double) int applyAsInt(double value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code DoubleToIntFunction}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code DoubleToIntFunction}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code DoubleToIntFunction}</li>
+ * </ul>
  *
  * @see DoubleToIntFunction
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleToLongFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleToLongFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,7 +28,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents a function that accepts a double-valued argument, may thrown
+ * Represents a function that accepts a double-valued argument, may throw
  * exception and produces a long-valued result. This is the
  * {@code double}-to-{@code long} primitive specialization for
  * {@link FunctionWithException}.
@@ -65,10 +66,10 @@ public interface DoubleToLongFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts this {@code DoubleToIntFunctionWithException} to a lifted
+	 * Converts this {@code DoubleToLongFunctionWithException} to a lifted
 	 * {@code DoubleToLongFunction} returning {@code null} in case of exception.
 	 *
-	 * @return the predicate that ignore error (return false in this case)
+	 * @return the function that ignore error (return 0 in this case)
 	 * @see #ignored(DoubleToLongFunctionWithException)
 	 */
 	@Override
@@ -83,13 +84,13 @@ public interface DoubleToLongFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <E extends Exception> DoubleToLongFunctionWithException<E> failing(Supplier<E> exceptionBuilder) {
 		return value -> {
@@ -98,7 +99,7 @@ public interface DoubleToLongFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a
+	 * Converts a {@code DoubleToLongFunctionWithException} to a
 	 * {@code DoubleToLongFunction} that convert exception to
 	 * {@code RuntimeException}.
 	 *
@@ -106,16 +107,18 @@ public interface DoubleToLongFunctionWithException<E extends Exception>
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleToLongFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleToLongFunction unchecked(DoubleToLongFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a
+	 * Converts a {@code DoubleToLongFunctionWithException} to a
 	 * {@code DoubleToLongFunction} that convert exception to
 	 * {@code RuntimeException} by using the provided mapping function.
 	 *
@@ -125,14 +128,16 @@ public interface DoubleToLongFunctionWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleToLongFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <E extends Exception> DoubleToLongFunction unchecked(DoubleToLongFunctionWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new DoubleToLongFunctionWithException<E>() {
 
 			@Override
@@ -149,8 +154,8 @@ public interface DoubleToLongFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code DoubleToLongFunction} returning {@code null} in case of exception.
+	 * Converts a {@code DoubleToLongFunctionWithException} to a lifted
+	 * {@code DoubleToLongFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -158,14 +163,16 @@ public interface DoubleToLongFunctionWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleToLongFunction lifted(DoubleToLongFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code DoubleToLongFunction} returning {@code null} in case of exception.
+	 * Converts a {@code DoubleToLongFunctionWithException} to a lifted
+	 * {@code DoubleToLongFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -173,6 +180,8 @@ public interface DoubleToLongFunctionWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleToLongFunction ignored(DoubleToLongFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleToLongFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleToLongFunctionWithException.java
@@ -32,6 +32,14 @@ import java.util.function.Supplier;
  * exception and produces a long-valued result. This is the
  * {@code double}-to-{@code long} primitive specialization for
  * {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsLong(double) long applyAsLong(double value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code DoubleToLongFunction}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code DoubleToLongFunction}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code DoubleToLongFunction}</li>
+ * </ul>
  *
  * @see DoubleToLongFunction
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleUnaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleUnaryOperatorWithException.java
@@ -32,6 +32,14 @@ import java.util.function.Supplier;
  * thrown exception and produces a {@code double}-valued result. This is the
  * primitive type specialization of {@link UnaryOperatorWithException} for
  * {@code double}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsDouble(double) double applyAsDouble(double operand)
+ * throws E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code DoubleUnaryOperator}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code DoubleUnaryOperator}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code DoubleUnaryOperator}</li>
+ * </ul>
  *
  * @see DoubleUnaryOperator
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/DoubleUnaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/DoubleUnaryOperatorWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -32,7 +33,6 @@ import java.util.function.Supplier;
  * primitive type specialization of {@link UnaryOperatorWithException} for
  * {@code double}.
  *
- * @author borettim
  * @see DoubleUnaryOperator
  * @param <E>
  *            the type of the potential exception of the function
@@ -134,16 +134,17 @@ public interface DoubleUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleUnaryOperatorException} to a
-	 * {@code DoubleUnaryOperator} that convert exception to
-	 * {@code RuntimeException}.
+	 * {@code DoubleUnaryOperator} that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleUnaryOperatorWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleUnaryOperator unchecked(DoubleUnaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -151,8 +152,8 @@ public interface DoubleUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleUnaryOperatorWithException} to a
-	 * {@code DoubleUnaryOperator} that convert exception to
-	 * {@code RuntimeException} by using the provided mapping function.
+	 * {@code DoubleUnaryOperator} that wraps exception to {@code RuntimeException}
+	 * by using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
@@ -160,14 +161,16 @@ public interface DoubleUnaryOperatorWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(DoubleUnaryOperatorWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <E extends Exception> DoubleUnaryOperator unchecked(DoubleUnaryOperatorWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new DoubleUnaryOperatorWithException<E>() {
 
 			@Override
@@ -185,7 +188,7 @@ public interface DoubleUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleUnaryOperatorWithException} to a lifted
-	 * {@code DoubleUnaryOperator} using {@code Optional} as return value.
+	 * {@code DoubleUnaryOperator} using {@code 0} as return value in case of error.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -193,6 +196,8 @@ public interface DoubleUnaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleUnaryOperator lifted(DoubleUnaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
@@ -200,7 +205,7 @@ public interface DoubleUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code DoubleUnaryOperatorWithException} to a lifted
-	 * {@code DoubleUnaryOperator} returning {@code null} in case of exception.
+	 * {@code DoubleUnaryOperator} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -208,6 +213,8 @@ public interface DoubleUnaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> DoubleUnaryOperator ignored(DoubleUnaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/ExceptionHandlerSupport.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ExceptionHandlerSupport.java
@@ -24,7 +24,6 @@ import java.util.function.Function;
 /**
  * Root interface to support global operations related to exception handling.
  *
- * @author borettim
  * @param <F>
  *            the type of the java standard functional interface. For example,
  *            {@code Function<T,R>}.
@@ -49,8 +48,23 @@ public interface ExceptionHandlerSupport<F, L> {
 	/**
 	 * Converts this functional interface to the corresponding one in java and wrap
 	 * exception using {@link #exceptionMapper()}.
+	 * <p>
+	 * Conceptually, the exception encapsulation is done in the following way :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		// do the underlying functional interface action and return result if
+	 * 		// applicable
+	 * 	} catch (Exception e) {
+	 * 		throw new exceptionMapper().apply(e);
+	 * 	}
+	 * }
+	 * </pre>
 	 *
 	 * @return the unchecked operation
+	 * @see #lift()
+	 * @see #ignore()
 	 */
 	F uncheck();
 
@@ -58,9 +72,47 @@ public interface ExceptionHandlerSupport<F, L> {
 	 * Converts this functional interface to a lifted one. A lifted version may or
 	 * may not have the same return type of the original one. When possible a
 	 * version returning an {@code Optional} is provided. For functional interface
-	 * without return value, this method will be identical to {@link #ignore()}
+	 * without return value, this method will be identical to {@link #ignore()}.
+	 * <p>
+	 * For functional interface with Object result, the principle is :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		return Optional.ofNullable(realaction(xxx));
+	 * 	} catch (Exception e) {
+	 * 		return Optional.empty();
+	 * 	}
+	 * }
+	 * </pre>
+	 *
+	 * For functional interface with primitive result, the principle is :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		return realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		return defaultValue;
+	 * 	}
+	 * }
+	 * </pre>
+	 *
+	 * For functional interface without result, the principle is :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		// do nothing
+	 * 	}
+	 * }
+	 * </pre>
 	 *
 	 * @return the lifted function
+	 * @see #uncheck()
+	 * @see #ignore()
 	 */
 	L lift();
 
@@ -69,7 +121,46 @@ public interface ExceptionHandlerSupport<F, L> {
 	 * functional interface returning a default value in case of error. For function
 	 * interface without return value, error will be silently ignored.
 	 *
+	 * <p>
+	 * For functional interface with Object result, the principle is :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		return realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		return null;
+	 * 	}
+	 * }
+	 * </pre>
+	 *
+	 * For functional interface with primitive result, the principle is :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		return realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		return defaultValue;
+	 * 	}
+	 * }
+	 * </pre>
+	 *
+	 * For functional interface without result, the principle is :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		// do nothing
+	 * 	}
+	 * }
+	 * </pre>
+	 *
 	 * @return the operation that ignore error
+	 * @see #uncheck()
+	 * @see #lift()
 	 */
 	F ignore();
 }

--- a/src/main/java/ch/powerunit/extensions/exceptions/FunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/FunctionWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
 /**
  * Represents a function that accepts one argument, may throw exception and
  * produces a result.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #apply(Object) R apply(T t) throws E}</b>&nbsp;-&nbsp;The
+ * functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code Function<T, R>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code Function<T, Optional<R>>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code Function<T, R>}</li>
+ * </ul>
  *
  * @see Function
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/FunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/FunctionWithException.java
@@ -214,7 +214,7 @@ public interface FunctionWithException<T, R, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code FunctionWithException} to a {@code Function} that convert
+	 * Converts a {@code FunctionWithException} to a {@code Function} that wraps
 	 * exception to {@code RuntimeException} by using the provided mapping function.
 	 *
 	 * @param function

--- a/src/main/java/ch/powerunit/extensions/exceptions/FunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/FunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -31,7 +32,6 @@ import java.util.function.Supplier;
  * Represents a function that accepts one argument, may throw exception and
  * produces a result.
  *
- * @author borettim
  * @see Function
  * @param <T>
  *            the type of the input to the function
@@ -63,6 +63,7 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 * @return the unchecked function
 	 * @see #unchecked(FunctionWithException)
 	 * @see #unchecked(FunctionWithException, Function)
+	 * @see Function
 	 */
 	@Override
 	default Function<T, R> uncheck() {
@@ -75,6 +76,7 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 *
 	 * @return the lifted function
 	 * @see #lifted(FunctionWithException)
+	 * @see Function
 	 */
 	@Override
 	default Function<T, Optional<R>> lift() {
@@ -88,6 +90,7 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 *
 	 * @return the function that ignore error
 	 * @see #ignored(FunctionWithException)
+	 * @see Function
 	 */
 	@Override
 	default Function<T, R> ignore() {
@@ -100,6 +103,7 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 *
 	 * @return the lifted function
 	 * @see #staged(FunctionWithException)
+	 * @see CompletionStage
 	 */
 	default Function<T, CompletionStage<R>> stage() {
 		return t -> ObjectReturnExceptionHandlerSupport.staged(() -> apply(t));
@@ -122,7 +126,7 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 *             if before is null
 	 *
 	 * @see #andThen(FunctionWithException)
-	 * @see Function#andThen(Function)
+	 * @see Function#compose(Function)
 	 */
 	default <V> FunctionWithException<V, R, E> compose(
 			FunctionWithException<? super V, ? extends T, ? extends E> before) {
@@ -144,10 +148,9 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 * @return a composed function that first applies this function and then applies
 	 *         the {@code after} function
 	 * @throws NullPointerException
-	 *             if after is null
-	 *
+	 *             if after is null *
 	 * @see #compose(FunctionWithException)
-	 * @see Function#compose(Function)
+	 * @see Function#andThen(Function)
 	 */
 	default <V> FunctionWithException<T, V, E> andThen(
 			FunctionWithException<? super R, ? extends V, ? extends E> after) {
@@ -175,9 +178,9 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the exception
 	 * @return a function that always throw exception
@@ -195,14 +198,16 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 * @param function
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(FunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, R, E extends Exception> Function<T, R> unchecked(FunctionWithException<T, R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -217,19 +222,21 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(FunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <T, R, E extends Exception> Function<T, R> unchecked(FunctionWithException<T, R, E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new FunctionWithException<T, R, E>() {
 
 			@Override
@@ -252,13 +259,15 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, R, E extends Exception> Function<T, Optional<R>> lifted(FunctionWithException<T, R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
@@ -271,13 +280,15 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, R, E extends Exception> Function<T, R> ignored(FunctionWithException<T, R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();
@@ -290,13 +301,15 @@ public interface FunctionWithException<T, R, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #stage()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, R, E extends Exception> Function<T, CompletionStage<R>> staged(FunctionWithException<T, R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).stage();

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntBinaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntBinaryOperatorWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -88,9 +89,11 @@ public interface IntBinaryOperatorWithException<E extends Exception>
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(IntBinaryOperatorWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntBinaryOperator unchecked(IntBinaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -107,14 +110,16 @@ public interface IntBinaryOperatorWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(IntBinaryOperatorWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <E extends Exception> IntBinaryOperator unchecked(IntBinaryOperatorWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new IntBinaryOperatorWithException<E>() {
 
 			@Override
@@ -132,7 +137,8 @@ public interface IntBinaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntBinaryOperatorWithException} to a lifted
-	 * {@code IntBinaryOperator} using {@code Optional} as return value.
+	 * {@code IntBinaryOperator} with {@code 0} as return value in case of
+	 * exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -140,6 +146,8 @@ public interface IntBinaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntBinaryOperator lifted(IntBinaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
@@ -147,7 +155,8 @@ public interface IntBinaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntBinaryOperatorWithException} to a lifted
-	 * {@code IntBinaryOperator} returning {@code null} in case of exception.
+	 * {@code IntBinaryOperator} with {@code 0} as return value in case of
+	 * exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -155,6 +164,8 @@ public interface IntBinaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntBinaryOperator ignored(IntBinaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntBinaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntBinaryOperatorWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
  * Represents an operation upon two {@code int}-valued operands, may thrown
  * exception and producing an {@code int}-valued result. This is the primitive
  * type specialization of {@link BinaryOperatorWithException} for {@code int}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsInt(int, int) int applyAsInt(int left, int right)
+ * throws E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code IntBinaryOperator}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code IntBinaryOperator}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code IntBinaryOperator}</li>
+ * </ul>
  *
  * @see IntBinaryOperator
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntConsumerWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.OPERATION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,11 +28,12 @@ import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 
 /**
- * Represents an operation that accepts a single input argument and returns no
- * result and may throw exception. Unlike most other functional interfaces,
- * {@code Consumer} is expected to operate via side-effects.
+ * Represents an operation that accepts a single {@code int}-valued argument,
+ * may throw exception and returns no result. This is the primitive type
+ * specialization of {@link ConsumerWithException} for {@code int}. Unlike most
+ * other functional interfaces, {@code IntConsumerWithException} is expected to
+ * operate via side-effects.
  *
- * @author borettim
  * @see IntConsumer
  * @param <E>
  *            the type of the potential exception of the operation
@@ -42,17 +44,17 @@ public interface IntConsumerWithException<E extends Exception> extends NoReturnE
 	/**
 	 * Performs this operation on the given argument.
 	 *
-	 * @param t
+	 * @param value
 	 *            the input argument
 	 * @throws E
 	 *             any exception
 	 * @see IntConsumer#accept(int)
 	 */
-	void accept(int t) throws E;
+	void accept(int value) throws E;
 
 	/**
 	 * Converts this {@code IntConsumerWithException} to a {@code IntConsumer} that
-	 * convert exception to {@code RuntimeException}.
+	 * wraps exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked operation
 	 * @see #unchecked(IntConsumerWithException)
@@ -117,15 +119,17 @@ public interface IntConsumerWithException<E extends Exception> extends NoReturnE
 
 	/**
 	 * Converts a {@code IntConsumerWithException} to a {@code IntConsumer} that
-	 * convert exception to {@code RuntimeException}.
+	 * wraps exception to {@code RuntimeException}.
 	 *
 	 * @param operation
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(IntConsumerWithException, Function)
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> IntConsumer unchecked(IntConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).uncheck();
@@ -133,7 +137,7 @@ public interface IntConsumerWithException<E extends Exception> extends NoReturnE
 
 	/**
 	 * Converts a {@code IntConsumerWithException} to a {@code IntConsumer} that
-	 * convert exception to {@code RuntimeException} by using the provided mapping
+	 * wraps exception to {@code RuntimeException} by using the provided mapping
 	 * function.
 	 *
 	 * @param operation
@@ -142,19 +146,21 @@ public interface IntConsumerWithException<E extends Exception> extends NoReturnE
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(IntConsumerWithException)
+	 * @throws NullPointerException
+	 *             if operation or exceptionMapper is null
 	 */
 	static <E extends Exception> IntConsumer unchecked(IntConsumerWithException<E> operation,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(operation, OPERATION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new IntConsumerWithException<E>() {
 
 			@Override
-			public void accept(int t) throws E {
-				operation.accept(t);
+			public void accept(int value) throws E {
+				operation.accept(value);
 			}
 
 			@Override
@@ -167,7 +173,7 @@ public interface IntConsumerWithException<E extends Exception> extends NoReturnE
 
 	/**
 	 * Converts a {@code IntConsumerWithException} to a lifted {@code IntConsumer}
-	 * returning {@code null} in case of exception.
+	 * ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
@@ -182,7 +188,7 @@ public interface IntConsumerWithException<E extends Exception> extends NoReturnE
 
 	/**
 	 * Converts a {@code IntConsumerWithException} to a lifted {@code IntConsumer}
-	 * returning {@code null} in case of exception.
+	 * ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
@@ -190,6 +196,8 @@ public interface IntConsumerWithException<E extends Exception> extends NoReturnE
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> IntConsumer ignored(IntConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).ignore();
@@ -197,13 +205,15 @@ public interface IntConsumerWithException<E extends Exception> extends NoReturnE
 
 	/**
 	 * Converts a {@code IntConsumerWithException} to a
-	 * {@code ConsumerWithException} returning {@code null}.
+	 * {@code ConsumerWithException}.
 	 *
 	 * @param operation
-	 *            to be lifted
+	 *            to be converted
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the function
+	 * @return the consumer
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> ConsumerWithException<Integer, E> asConsumer(IntConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL)::accept;

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntConsumerWithException.java
@@ -33,6 +33,14 @@ import java.util.function.Supplier;
  * specialization of {@link ConsumerWithException} for {@code int}. Unlike most
  * other functional interfaces, {@code IntConsumerWithException} is expected to
  * operate via side-effects.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #accept(int) void accept(int value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code IntConsumer}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code IntConsumer}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code IntConsumer}</li>
+ * </ul>
  *
  * @see IntConsumer
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntFunctionWithException.java
@@ -33,6 +33,14 @@ import java.util.function.Supplier;
  * Represents a function that accepts an int-valued argument, may throw
  * exception and produces a result. This is the {@code int}-consuming primitive
  * specialization for {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #apply(int) R apply(int value) throws E}</b>&nbsp;-&nbsp;The
+ * functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code IntFunction<R>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code IntFunction<Optional<R>>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code IntFunction<R>}</li>
+ * </ul>
  *
  * @see IntFunction
  * @param <R>

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntPredicateWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntPredicateWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
  * Represents a predicate (boolean-valued function) of one {@code int}-valued
  * argument that may throw exception. This is the {@code int}-consuming
  * primitive type specialization of {@link PredicateWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #test(int) boolean test(int value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code IntPredicate}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code IntPredicate}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code IntPredicate}</li>
+ * </ul>
  *
  * @see IntPredicate
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntPredicateWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntPredicateWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.PREDICATE_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,10 +28,10 @@ import java.util.function.IntPredicate;
 import java.util.function.Supplier;
 
 /**
- * Represents a predicate (boolean-valued function) of one argument and may
- * throw an exception.
+ * Represents a predicate (boolean-valued function) of one {@code int}-valued
+ * argument that may throw exception. This is the {@code int}-consuming
+ * primitive type specialization of {@link PredicateWithException}.
  *
- * @author borettim
  * @see IntPredicate
  * @param <E>
  *            the type of the potential exception of the function
@@ -42,7 +43,7 @@ public interface IntPredicateWithException<E extends Exception>
 	/**
 	 * Evaluates this predicate on the given argument.
 	 *
-	 * @param t
+	 * @param value
 	 *            the input argument
 	 * @return {@code true} if the input argument matches the predicate, otherwise
 	 *         {@code false}
@@ -50,7 +51,7 @@ public interface IntPredicateWithException<E extends Exception>
 	 *             any exception
 	 * @see IntPredicate#test(int)
 	 */
-	boolean test(int t) throws E;
+	boolean test(int value) throws E;
 
 	@Override
 	default IntPredicate uncheckOrIgnore(boolean uncheck) {
@@ -156,22 +157,24 @@ public interface IntPredicateWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntPredicateWithException} to a {@code IntPredicate} that
-	 * convert exception to {@code RuntimeException}.
+	 * wraps exception to {@code RuntimeException}.
 	 *
 	 * @param predicate
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked predicate
 	 * @see #uncheck()
 	 * @see #unchecked(IntPredicateWithException, Function)
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <E extends Exception> IntPredicate unchecked(IntPredicateWithException<E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code PredicateWithException} to a {@code Predicate} that convert
+	 * Converts a {@code PredicateWithException} to a {@code Predicate} that wraps
 	 * exception to {@code RuntimeException} by using the provided mapping function.
 	 *
 	 * @param predicate
@@ -180,19 +183,21 @@ public interface IntPredicateWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked predicate
 	 * @see #uncheck()
 	 * @see #unchecked(IntPredicateWithException)
+	 * @throws NullPointerException
+	 *             if predicate or exceptionMapper is null
 	 */
 	static <E extends Exception> IntPredicate unchecked(IntPredicateWithException<E> predicate,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(predicate, PREDICATE_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new IntPredicateWithException<E>() {
 
 			@Override
-			public boolean test(int t) throws E {
-				return predicate.test(t);
+			public boolean test(int value) throws E {
+				return predicate.test(value);
 			}
 
 			@Override
@@ -205,14 +210,16 @@ public interface IntPredicateWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntPredicateWithException} to a lifted {@code IntPredicate}
-	 * returning {@code null} in case of exception.
+	 * returning {@code false} in case of exception.
 	 *
 	 * @param predicate
 	 *            to be lifted
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the lifted function
+	 * @return the lifted predicate
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <E extends Exception> IntPredicate lifted(IntPredicateWithException<E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).lift();
@@ -220,14 +227,16 @@ public interface IntPredicateWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntPredicateWithException} to a lifted {@code IntPredicate}
-	 * returning {@code null} in case of exception.
+	 * returning {@code false} in case of exception.
 	 *
 	 * @param predicate
 	 *            to be lifted
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the lifted function
+	 * @return the lifted predicate
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <E extends Exception> IntPredicate ignored(IntPredicateWithException<E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntSupplierWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntSupplierWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.SUPPLIER_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,12 +28,15 @@ import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 
 /**
- * Represents a supplier of {@code int}-valued results that may throw exception.
+ * Represents a supplier of {@code int}-valued results and may throw exception.
  * This is the {@code int}-producing primitive specialization of
- * {@link Supplier}.
+ * {@link SupplierWithException}.
  *
- * @author borettim
- * @see Supplier
+ * <p>
+ * There is no requirement that a distinct result be returned each time the
+ * supplier is invoked.
+ *
+ * @see IntSupplier
  * @param <E>
  *            the type of the potential exception of the operation
  */
@@ -45,7 +49,7 @@ public interface IntSupplierWithException<E extends Exception>
 	 *
 	 * @throws E
 	 *             any exception
-	 * @return a boolean
+	 * @return a result
 	 * @see IntSupplier#getAsInt()
 	 */
 	int getAsInt() throws E;
@@ -79,15 +83,17 @@ public interface IntSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntSupplierWithException} to a {@code IntSupplier} that
-	 * convert exception to {@code RuntimeException}. o
+	 * wraps exception to {@code RuntimeException}.
 	 *
 	 * @param supplier
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked supplier
 	 * @see #uncheck()
 	 * @see #unchecked(IntSupplierWithException, Function)
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> IntSupplier unchecked(IntSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).uncheck();
@@ -95,7 +101,7 @@ public interface IntSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntSupplierWithException} to a {@code IntSupplier} that
-	 * convert exception to {@code RuntimeException} by using the provided mapping
+	 * wraps exception to {@code RuntimeException} by using the provided mapping
 	 * function.
 	 *
 	 * @param supplier
@@ -104,14 +110,16 @@ public interface IntSupplierWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked supplier
 	 * @see #uncheck()
 	 * @see #unchecked(IntSupplierWithException)
+	 * @throws NullPointerException
+	 *             if supplier or exceptionMapper is null
 	 */
 	static <E extends Exception> IntSupplier unchecked(IntSupplierWithException<E> supplier,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(supplier, SUPPLIER_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new IntSupplierWithException<E>() {
 
 			@Override
@@ -129,7 +137,7 @@ public interface IntSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntSupplierWithException} to a lifted {@code IntSupplier}
-	 * returning {@code null} in case of exception.
+	 * returning {@code 0} in case of exception.
 	 *
 	 * @param supplier
 	 *            to be lifted
@@ -137,6 +145,8 @@ public interface IntSupplierWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted supplier
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> IntSupplier lifted(IntSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).lift();
@@ -144,7 +154,7 @@ public interface IntSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntSupplierWithException} to a lifted {@code IntSupplier}
-	 * returning {@code null} in case of exception.
+	 * returning {@code 0} in case of exception.
 	 *
 	 * @param supplier
 	 *            to be lifted
@@ -152,6 +162,8 @@ public interface IntSupplierWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted supplier
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> IntSupplier ignored(IntSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntSupplierWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntSupplierWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
  * Represents a supplier of {@code int}-valued results and may throw exception.
  * This is the {@code int}-producing primitive specialization of
  * {@link SupplierWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #getAsInt() int getAsInt() throws E}</b>&nbsp;-&nbsp;The
+ * functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code IntSupplier}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code IntSupplier}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code IntSupplier}</li>
+ * </ul>
  *
  * <p>
  * There is no requirement that a distinct result be returned each time the

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntToDoubleFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntToDoubleFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,10 +28,11 @@ import java.util.function.IntToDoubleFunction;
 import java.util.function.Supplier;
 
 /**
- * Represents a predicate (boolean-valued function) of one argument and may
- * throw an exception.
+ * Represents a function that accepts an int-valued argument, may throw an
+ * exception and produces a double-valued result. This is the
+ * {@code int}-to-{@code double} primitive specialization for
+ * {@link FunctionWithException}.
  *
- * @author borettim
  * @see IntToDoubleFunction
  * @param <E>
  *            the type of the potential exception of the function
@@ -40,16 +42,16 @@ public interface IntToDoubleFunctionWithException<E extends Exception>
 		extends PrimitiveReturnExceptionHandlerSupport<IntToDoubleFunction> {
 
 	/**
-	 * Evaluates this predicate on the given argument.
+	 * Applies this function to the given argument.
 	 *
-	 * @param t
-	 *            the input argument
-	 * @return the result
+	 * @param value
+	 *            the function argument
+	 * @return the function result
 	 * @throws E
 	 *             any exception
 	 * @see IntToDoubleFunction#applyAsDouble(int)
 	 */
-	double applyAsDouble(int t) throws E;
+	double applyAsDouble(int value) throws E;
 
 	@Override
 	default IntToDoubleFunction uncheckOrIgnore(boolean uncheck) {
@@ -64,13 +66,13 @@ public interface IntToDoubleFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <E extends Exception> IntToDoubleFunctionWithException<E> failing(Supplier<E> exceptionBuilder) {
 		return t -> {
@@ -79,9 +81,8 @@ public interface IntToDoubleFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a
-	 * {@code IntToDoubleFunction} that convert exception to
-	 * {@code RuntimeException}.
+	 * Converts a {@code IntToDoubleFunctionWithException} to a
+	 * {@code IntToDoubleFunction} that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
@@ -90,15 +91,17 @@ public interface IntToDoubleFunctionWithException<E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(IntToDoubleFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntToDoubleFunction unchecked(IntToDoubleFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a
-	 * {@code IntToDoubleFunction} that convert exception to
-	 * {@code RuntimeException} by using the provided mapping function.
+	 * Converts a {@code IntToDoubleFunctionWithException} to a
+	 * {@code IntToDoubleFunction} that wraps exception to {@code RuntimeException}
+	 * by using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
@@ -106,19 +109,21 @@ public interface IntToDoubleFunctionWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(IntToDoubleFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <E extends Exception> IntToDoubleFunction unchecked(IntToDoubleFunctionWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new IntToDoubleFunctionWithException<E>() {
 
 			@Override
-			public double applyAsDouble(int t) throws E {
-				return function.applyAsDouble(t);
+			public double applyAsDouble(int value) throws E {
+				return function.applyAsDouble(value);
 			}
 
 			@Override
@@ -130,8 +135,8 @@ public interface IntToDoubleFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code IntToDoubleFunction} returning {@code null} in case of exception.
+	 * Converts a {@code IntToDoubleFunctionWithException} to a lifted
+	 * {@code IntToDoubleFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -139,14 +144,16 @@ public interface IntToDoubleFunctionWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntToDoubleFunction lifted(IntToDoubleFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code IntToDoubleFunction} returning {@code null} in case of exception.
+	 * Converts a {@code IntToDoubleFunctionWithException} to a lifted
+	 * {@code IntToDoubleFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -154,6 +161,8 @@ public interface IntToDoubleFunctionWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntToDoubleFunction ignored(IntToDoubleFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntToDoubleFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntToDoubleFunctionWithException.java
@@ -32,6 +32,14 @@ import java.util.function.Supplier;
  * exception and produces a double-valued result. This is the
  * {@code int}-to-{@code double} primitive specialization for
  * {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsDouble(int) double applyAsDouble(int value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code IntToDoubleFunction}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code IntToDoubleFunction}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code IntToDoubleFunction}</li>
+ * </ul>
  *
  * @see IntToDoubleFunction
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntToLongFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntToLongFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -32,7 +33,6 @@ import java.util.function.Supplier;
  * {@code int}-to-{@code long} primitive specialization for
  * {@link FunctionWithException}.
  *
- * @author borettim
  * @see IntToLongFunction
  * @param <E>
  *            the type of the potential exception of the function
@@ -66,13 +66,13 @@ public interface IntToLongFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <E extends Exception> IntToLongFunctionWithException<E> failing(Supplier<E> exceptionBuilder) {
 		return t -> {
@@ -81,25 +81,27 @@ public interface IntToLongFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a
-	 * {@code IntToLongFunction} that convert exception to {@code RuntimeException}.
+	 * Converts a {@code IntToLongFunctionWithException} to a
+	 * {@code IntToLongFunction} that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(IntToLongFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntToLongFunction unchecked(IntToLongFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a
-	 * {@code IntToLongFunction} that convert exception to {@code RuntimeException}
-	 * by using the provided mapping function.
+	 * Converts a {@code IntToLongFunctionWithException} to a
+	 * {@code IntToLongFunction} that wraps exception to {@code RuntimeException} by
+	 * using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
@@ -107,14 +109,16 @@ public interface IntToLongFunctionWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(IntToLongFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <E extends Exception> IntToLongFunction unchecked(IntToLongFunctionWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new IntToLongFunctionWithException<E>() {
 
 			@Override
@@ -131,8 +135,8 @@ public interface IntToLongFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code IntToLongFunction} returning {@code null} in case of exception.
+	 * Converts a {@code IntToLongFunctionWithException} to a lifted
+	 * {@code IntToLongFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -140,14 +144,16 @@ public interface IntToLongFunctionWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntToLongFunction lifted(IntToLongFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code IntToLongFunction} returning {@code null} in case of exception.
+	 * Converts a {@code IntToLongFunctionWithException} to a lifted
+	 * {@code IntToLongFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -155,6 +161,8 @@ public interface IntToLongFunctionWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntToLongFunction ignored(IntToLongFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntToLongFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntToLongFunctionWithException.java
@@ -32,6 +32,14 @@ import java.util.function.Supplier;
  * exception and produces a long-valued result. This is the
  * {@code int}-to-{@code long} primitive specialization for
  * {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsLong(int) long applyAsLong(int value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code IntToLongFunction}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code IntToLongFunction}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code IntToLongFunction}</li>
+ * </ul>
  *
  * @see IntToLongFunction
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntUnaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntUnaryOperatorWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,9 +28,10 @@ import java.util.function.IntUnaryOperator;
 import java.util.function.Supplier;
 
 /**
- * Represents a int unary operator with exception.
+ * Represents an operation on a single {@code int}-valued operand that produces
+ * an {@code int}-valued result and may throws exception. This is the primitive
+ * type specialization of {@link UnaryOperatorWithException} for {@code int}.
  *
- * @author borettim
  * @see IntUnaryOperator
  * @param <E>
  *            the type of the potential exception of the function
@@ -39,16 +41,16 @@ public interface IntUnaryOperatorWithException<E extends Exception>
 		extends PrimitiveReturnExceptionHandlerSupport<IntUnaryOperator> {
 
 	/**
-	 * Applies this function to the given arguments.
+	 * Applies this operator to the given operand.
 	 *
-	 * @param t
-	 *            the first function argument
-	 * @return the function result
+	 * @param operand
+	 *            the operand
+	 * @return the operator result
 	 * @throws E
 	 *             any exception
 	 * @see IntUnaryOperator#applyAsInt(int)
 	 */
-	int applyAsInt(int t) throws E;
+	int applyAsInt(int operand) throws E;
 
 	@Override
 	default IntUnaryOperator uncheckOrIgnore(boolean uncheck) {
@@ -131,15 +133,17 @@ public interface IntUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntUnaryOperatorException} to a {@code IntUnaryOperator}
-	 * that convert exception to {@code RuntimeException}.
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(IntUnaryOperatorWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntUnaryOperator unchecked(IntUnaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -147,8 +151,8 @@ public interface IntUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntUnaryOperatorWithException} to a
-	 * {@code IntUnaryOperator} that convert exception to {@code RuntimeException}
-	 * by using the provided mapping function.
+	 * {@code IntUnaryOperator} that wraps exception to {@code RuntimeException} by
+	 * using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
@@ -156,19 +160,21 @@ public interface IntUnaryOperatorWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(IntUnaryOperatorWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <E extends Exception> IntUnaryOperator unchecked(IntUnaryOperatorWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new IntUnaryOperatorWithException<E>() {
 
 			@Override
-			public int applyAsInt(int t) throws E {
-				return function.applyAsInt(t);
+			public int applyAsInt(int operand) throws E {
+				return function.applyAsInt(operand);
 			}
 
 			@Override
@@ -181,7 +187,7 @@ public interface IntUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntUnaryOperatorWithException} to a lifted
-	 * {@code IntUnaryOperator} using {@code Optional} as return value.
+	 * {@code IntUnaryOperator} using {@code 0} as return value in case of error.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -189,6 +195,8 @@ public interface IntUnaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntUnaryOperator lifted(IntUnaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
@@ -196,7 +204,7 @@ public interface IntUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code IntUnaryOperatorWithException} to a lifted
-	 * {@code IntUnaryOperator} returning {@code null} in case of exception.
+	 * {@code IntUnaryOperator} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -204,6 +212,8 @@ public interface IntUnaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> IntUnaryOperator ignored(IntUnaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/IntUnaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/IntUnaryOperatorWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
  * Represents an operation on a single {@code int}-valued operand that produces
  * an {@code int}-valued result and may throws exception. This is the primitive
  * type specialization of {@link UnaryOperatorWithException} for {@code int}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsInt(int) int applyAsInt(int operand) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code IntUnaryOperator}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code IntUnaryOperator}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code IntUnaryOperator}</li>
+ * </ul>
  *
  * @see IntUnaryOperator
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongBinaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongBinaryOperatorWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
  * Represents an operation upon two {@code long}-valued operands and producing a
  * {@code long}-valued result which may throw exception. This is the primitive
  * type specialization of {@link BinaryOperatorWithException} for {@code long}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsLong(long, long) long applyAsLong(long left, long
+ * right) throws E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code LongBinaryOperator}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code LongBinaryOperator}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code LongBinaryOperator}</li>
+ * </ul>
  *
  * @see LongBinaryOperator
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongBinaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongBinaryOperatorWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,9 +28,10 @@ import java.util.function.LongBinaryOperator;
 import java.util.function.Supplier;
 
 /**
- * Represents a long binary operator with exception.
+ * Represents an operation upon two {@code long}-valued operands and producing a
+ * {@code long}-valued result which may throw exception. This is the primitive
+ * type specialization of {@link BinaryOperatorWithException} for {@code long}.
  *
- * @author borettim
  * @see LongBinaryOperator
  * @param <E>
  *            the type of the potential exception of the function
@@ -39,24 +41,24 @@ public interface LongBinaryOperatorWithException<E extends Exception>
 		extends PrimitiveReturnExceptionHandlerSupport<LongBinaryOperator> {
 
 	/**
-	 * Applies this function to the given arguments.
+	 * Applies this operator to the given operands.
 	 *
-	 * @param t
-	 *            the first function argument
-	 * @param u
-	 *            the second function argument
-	 * @return the function result
+	 * @param left
+	 *            the first operand
+	 * @param right
+	 *            the second operand
+	 * @return the operator result
 	 * @throws E
 	 *             any exception
 	 * @see LongBinaryOperator#applyAsLong(long, long)
 	 */
-	long applyAsLong(long t, long u) throws E;
+	long applyAsLong(long left, long right) throws E;
 
 	@Override
 	default LongBinaryOperator uncheckOrIgnore(boolean uncheck) {
-		return (t, u) -> {
+		return (left, right) -> {
 			try {
-				return applyAsLong(t, u);
+				return applyAsLong(left, right);
 			} catch (Exception e) {
 				PrimitiveReturnExceptionHandlerSupport.handleException(uncheck, e, exceptionMapper());
 				return 0;
@@ -88,9 +90,11 @@ public interface LongBinaryOperatorWithException<E extends Exception>
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(LongBinaryOperatorWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> LongBinaryOperator unchecked(LongBinaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -107,19 +111,21 @@ public interface LongBinaryOperatorWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(LongBinaryOperatorWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <E extends Exception> LongBinaryOperator unchecked(LongBinaryOperatorWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new LongBinaryOperatorWithException<E>() {
 
 			@Override
-			public long applyAsLong(long t, long u) throws E {
-				return function.applyAsLong(t, u);
+			public long applyAsLong(long left, long right) throws E {
+				return function.applyAsLong(left, right);
 			}
 
 			@Override
@@ -132,7 +138,8 @@ public interface LongBinaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongBinaryOperatorWithException} to a lifted
-	 * {@code LongBinaryOperator} using {@code Optional} as return value.
+	 * {@code LongBinaryOperator} with {@code 0} as return value in case of
+	 * exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -140,6 +147,8 @@ public interface LongBinaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> LongBinaryOperator lifted(LongBinaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
@@ -147,7 +156,8 @@ public interface LongBinaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongBinaryOperatorWithException} to a lifted
-	 * {@code LongBinaryOperator} returning {@code null} in case of exception.
+	 * {@code LongBinaryOperator} with {@code 0} as return value in case of
+	 * exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -155,6 +165,8 @@ public interface LongBinaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> LongBinaryOperator ignored(LongBinaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongConsumerWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.OPERATION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,11 +28,12 @@ import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 
 /**
- * Represents an operation that accepts a single input argument and returns no
- * result and may throw exception. Unlike most other functional interfaces,
- * {@code Consumer} is expected to operate via side-effects.
+ * Represents an operation that accepts a single {@code long}-valued argument,
+ * may throw exception and returns no result. This is the primitive type
+ * specialization of {@link ConsumerWithException} for {@code long}. Unlike most
+ * other functional interfaces, {@code LongConsumerWithException} is expected to
+ * operate via side-effects.
  *
- * @author borettim
  * @see LongConsumer
  * @param <E>
  *            the type of the potential exception of the operation
@@ -42,13 +44,13 @@ public interface LongConsumerWithException<E extends Exception> extends NoReturn
 	/**
 	 * Performs this operation on the given argument.
 	 *
-	 * @param t
+	 * @param value
 	 *            the input argument
 	 * @throws E
 	 *             any exception
 	 * @see LongConsumer#accept(long)
 	 */
-	void accept(long t) throws E;
+	void accept(long value) throws E;
 
 	/**
 	 * Converts this {@code LongConsumerWithException} to a {@code LongConsumer}
@@ -123,9 +125,11 @@ public interface LongConsumerWithException<E extends Exception> extends NoReturn
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(LongConsumerWithException, Function)
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> LongConsumer unchecked(LongConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).uncheck();
@@ -142,19 +146,21 @@ public interface LongConsumerWithException<E extends Exception> extends NoReturn
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(LongConsumerWithException)
+	 * @throws NullPointerException
+	 *             if operation or exceptionMapper is null
 	 */
 	static <E extends Exception> LongConsumer unchecked(LongConsumerWithException<E> operation,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(operation, OPERATION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new LongConsumerWithException<E>() {
 
 			@Override
-			public void accept(long t) throws E {
-				operation.accept(t);
+			public void accept(long value) throws E {
+				operation.accept(value);
 			}
 
 			@Override
@@ -167,7 +173,7 @@ public interface LongConsumerWithException<E extends Exception> extends NoReturn
 
 	/**
 	 * Converts a {@code LongConsumerWithException} to a lifted {@code LongConsumer}
-	 * returning {@code null} in case of exception.
+	 * ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
@@ -175,6 +181,8 @@ public interface LongConsumerWithException<E extends Exception> extends NoReturn
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> LongConsumer lifted(LongConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).lift();
@@ -182,7 +190,7 @@ public interface LongConsumerWithException<E extends Exception> extends NoReturn
 
 	/**
 	 * Converts a {@code LongConsumerWithException} to a lifted {@code LongConsumer}
-	 * returning {@code null} in case of exception.
+	 * ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
@@ -190,6 +198,8 @@ public interface LongConsumerWithException<E extends Exception> extends NoReturn
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> LongConsumer ignored(LongConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).ignore();
@@ -197,13 +207,15 @@ public interface LongConsumerWithException<E extends Exception> extends NoReturn
 
 	/**
 	 * Converts a {@code LongConsumerWithException} to a
-	 * {@code ConsumerWithException} returning {@code null}.
+	 * {@code ConsumerWithException}.
 	 *
 	 * @param operation
-	 *            to be lifted
+	 *            to be converted
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the function
+	 * @return the consumer
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> ConsumerWithException<Long, E> asConsumer(LongConsumerWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL)::accept;

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongConsumerWithException.java
@@ -33,6 +33,14 @@ import java.util.function.Supplier;
  * specialization of {@link ConsumerWithException} for {@code long}. Unlike most
  * other functional interfaces, {@code LongConsumerWithException} is expected to
  * operate via side-effects.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #accept(long) void accept(long value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code LongConsumer}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code LongConsumer}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code LongConsumer}</li>
+ * </ul>
  *
  * @see LongConsumer
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -29,10 +30,10 @@ import java.util.function.LongFunction;
 import java.util.function.Supplier;
 
 /**
- * Represents a function that accepts one argument, may throw exception and
- * produces a result.
+ * Represents a function that accepts a long-valued argument, may throw
+ * exception and produces a result. This is the {@code long}-consuming primitive
+ * specialization for {@link FunctionWithException}.
  *
- * @author borettim
  * @see LongFunction
  * @param <R>
  *            the type of the result of the function
@@ -41,23 +42,23 @@ import java.util.function.Supplier;
  */
 @FunctionalInterface
 public interface LongFunctionWithException<R, E extends Exception>
-		extends ObjectReturnExceptionHandlerSupport<LongFunction<R>, Function<Long, Optional<R>>, R> {
+		extends ObjectReturnExceptionHandlerSupport<LongFunction<R>, LongFunction<Optional<R>>, R> {
 
 	/**
 	 * Applies this function to the given argument.
 	 *
-	 * @param t
+	 * @param value
 	 *            the function argument
 	 * @return the function result
 	 * @throws E
 	 *             any exception
 	 * @see LongFunction#apply(long)
 	 */
-	R apply(long t) throws E;
+	R apply(long value) throws E;
 
 	/**
-	 * Converts this {@code DoubleFunctionWithException} to a {@code LongFunction}
-	 * that convert exception to {@code RuntimeException}.
+	 * Converts this {@code LongFunctionWithException} to a {@code LongFunction}
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked function
 	 * @see #unchecked(LongFunctionWithException)
@@ -69,20 +70,20 @@ public interface LongFunctionWithException<R, E extends Exception>
 	}
 
 	/**
-	 * Converts this {@code DoubleFunctionWithException} to a lifted
-	 * {@code Function} using {@code Optional} as return value.
+	 * Converts this {@code LongFunctionWithException} to a lifted
+	 * {@code LongFunction} using {@code Optional} as return value.
 	 *
 	 * @return the lifted function
 	 * @see #lifted(LongFunctionWithException)
 	 */
 	@Override
-	default Function<Long, Optional<R>> lift() {
+	default LongFunction<Optional<R>> lift() {
 		return t -> ObjectReturnExceptionHandlerSupport.unchecked(() -> Optional.ofNullable(apply(t)),
 				notThrowingHandler());
 	}
 
 	/**
-	 * Converts this {@code DoubleFunctionWithException} to a lifted
+	 * Converts this {@code LongFunctionWithException} to a lifted
 	 * {@code LongFunction} returning {@code null} in case of exception.
 	 *
 	 * @return the function that ignore error
@@ -94,8 +95,8 @@ public interface LongFunctionWithException<R, E extends Exception>
 	}
 
 	/**
-	 * Convert this {@code DoubleFunctionWithException} to a lifted
-	 * {@code LongFunction} return {@code CompletionStage} as return value.
+	 * Convert this {@code LongFunctionWithException} to a lifted
+	 * {@code LongFunction} returning {@code CompletionStage} as return value.
 	 *
 	 * @return the lifted function
 	 * @see #staged(LongFunctionWithException)
@@ -110,7 +111,7 @@ public interface LongFunctionWithException<R, E extends Exception>
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the exception
 	 * @return a function that always throw exception
@@ -122,8 +123,8 @@ public interface LongFunctionWithException<R, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code FunctionWithException} to a {@code LongFunction} that
-	 * convert exception to {@code RuntimeException}.
+	 * Converts a {@code FunctionWithException} to a {@code LongFunction} that wraps
+	 * to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
@@ -134,14 +135,16 @@ public interface LongFunctionWithException<R, E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(LongFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <R, E extends Exception> LongFunction<R> unchecked(LongFunctionWithException<R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code DoubleFunctionWithException} to a {@code LongFunction} that
-	 * convert exception to {@code RuntimeException} by using the provided mapping
+	 * Converts a {@code LongFunctionWithException} to a {@code LongFunction} that
+	 * wraps exception to {@code RuntimeException} by using the provided mapping
 	 * function.
 	 *
 	 * @param function
@@ -149,22 +152,24 @@ public interface LongFunctionWithException<R, E extends Exception>
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(LongFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <R, E extends Exception> LongFunction<R> unchecked(LongFunctionWithException<R, E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new LongFunctionWithException<R, E>() {
 
 			@Override
-			public R apply(long t) throws E {
-				return function.apply(t);
+			public R apply(long value) throws E {
+				return function.apply(value);
 			}
 
 			@Override
@@ -176,51 +181,57 @@ public interface LongFunctionWithException<R, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code DoubleFunctionWithException} to a lifted {@code Function}
+	 * Converts a {@code LongFunctionWithException} to a lifted {@code Function}
 	 * using {@code Optional} as return value.
 	 *
 	 * @param function
 	 *            to be lifted
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
-	static <R, E extends Exception> Function<Long, Optional<R>> lifted(LongFunctionWithException<R, E> function) {
+	static <R, E extends Exception> LongFunction<Optional<R>> lifted(LongFunctionWithException<R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
 	}
 
 	/**
-	 * Converts a {@code DoubleFunctionWithException} to a lifted
-	 * {@code LongFunction} returning {@code null} in case of exception.
+	 * Converts a {@code LongFunctionWithException} to a lifted {@code LongFunction}
+	 * returning {@code null} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <R, E extends Exception> LongFunction<R> ignored(LongFunctionWithException<R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();
 	}
 
 	/**
-	 * Convert this {@code DoubleFunctionWithException} to a lifted
+	 * Convert this {@code LongFunctionWithException} to a lifted
 	 * {@code LongFunction} return {@code CompletionStage} as return value.
 	 *
 	 * @param function
 	 *            to be lifted
 	 * @param <R>
-	 *            the type of the output object to the function
+	 *            the type of the result of the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #stage()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <R, E extends Exception> LongFunction<CompletionStage<R>> staged(LongFunctionWithException<R, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).stage();

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongFunctionWithException.java
@@ -33,6 +33,14 @@ import java.util.function.Supplier;
  * Represents a function that accepts a long-valued argument, may throw
  * exception and produces a result. This is the {@code long}-consuming primitive
  * specialization for {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #apply(long) R apply(long value) throws E}</b>&nbsp;-&nbsp;The
+ * functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code LongFunction<R>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code LongFunction<Optional<R>>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code LongFunction<R>}</li>
+ * </ul>
  *
  * @see LongFunction
  * @param <R>

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongPredicateWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongPredicateWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.PREDICATE_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,10 +28,10 @@ import java.util.function.LongPredicate;
 import java.util.function.Supplier;
 
 /**
- * Represents a predicate (boolean-valued function) of one argument and may
- * throw an exception.
+ * Represents a predicate (boolean-valued function) of one {@code long}-valued
+ * argument that may throw exception. This is the {@code long}-consuming
+ * primitive type specialization of {@link PredicateWithException}.
  *
- * @author borettim
  * @see LongPredicate
  * @param <E>
  *            the type of the potential exception of the function
@@ -42,7 +43,7 @@ public interface LongPredicateWithException<E extends Exception>
 	/**
 	 * Evaluates this predicate on the given argument.
 	 *
-	 * @param t
+	 * @param value
 	 *            the input argument
 	 * @return {@code true} if the input argument matches the predicate, otherwise
 	 *         {@code false}
@@ -50,7 +51,7 @@ public interface LongPredicateWithException<E extends Exception>
 	 *             any exception
 	 * @see LongPredicate#test(long)
 	 */
-	boolean test(long t) throws E;
+	boolean test(long value) throws E;
 
 	@Override
 	default LongPredicate uncheckOrIgnore(boolean uncheck) {
@@ -165,13 +166,15 @@ public interface LongPredicateWithException<E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(LongPredicateWithException, Function)
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <E extends Exception> LongPredicate unchecked(LongPredicateWithException<E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code PredicateWithException} to a {@code Predicate} that convert
+	 * Converts a {@code PredicateWithException} to a {@code Predicate} that wraps
 	 * exception to {@code RuntimeException} by using the provided mapping function.
 	 *
 	 * @param predicate
@@ -180,19 +183,21 @@ public interface LongPredicateWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked predicate
 	 * @see #uncheck()
 	 * @see #unchecked(LongPredicateWithException)
+	 * @throws NullPointerException
+	 *             if predicate or exceptionMapper is null
 	 */
 	static <E extends Exception> LongPredicate unchecked(LongPredicateWithException<E> predicate,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(predicate, PREDICATE_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new LongPredicateWithException<E>() {
 
 			@Override
-			public boolean test(long t) throws E {
-				return predicate.test(t);
+			public boolean test(long value) throws E {
+				return predicate.test(value);
 			}
 
 			@Override
@@ -205,14 +210,16 @@ public interface LongPredicateWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongPredicateWithException} to a lifted
-	 * {@code LongPredicate} returning {@code null} in case of exception.
+	 * {@code LongPredicate} returning {@code 0} in case of exception.
 	 *
 	 * @param predicate
 	 *            to be lifted
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the lifted function
+	 * @return the lifted predicate
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <E extends Exception> LongPredicate lifted(LongPredicateWithException<E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).lift();
@@ -220,14 +227,16 @@ public interface LongPredicateWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongPredicateWithException} to a lifted
-	 * {@code LongPredicate} returning {@code null} in case of exception.
+	 * {@code LongPredicate} returning {@code 0} in case of exception.
 	 *
 	 * @param predicate
 	 *            to be lifted
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the lifted function
+	 * @return the lifted predicate
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <E extends Exception> LongPredicate ignored(LongPredicateWithException<E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongPredicateWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongPredicateWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
  * Represents a predicate (boolean-valued function) of one {@code long}-valued
  * argument that may throw exception. This is the {@code long}-consuming
  * primitive type specialization of {@link PredicateWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #test(long) boolean test(long value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code LongPredicate}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code LongPredicate}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code LongPredicate}</li>
+ * </ul>
  *
  * @see LongPredicate
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongSupplierWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongSupplierWithException.java
@@ -31,6 +31,14 @@ import java.util.function.Supplier;
  * Represents a supplier of {@code long}-valued results and may throw exception.
  * This is the {@code long}-producing primitive specialization of
  * {@link SupplierWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #getAsLong() long getAsLong() throws E}</b>&nbsp;-&nbsp;The
+ * functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code LongSupplier}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code LongSupplier}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code LongSupplier}</li>
+ * </ul>
  *
  * <p>
  * There is no requirement that a distinct result be returned each time the

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongSupplierWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongSupplierWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.SUPPLIER_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,12 +28,15 @@ import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 /**
- * Represents a supplier of {@code long}-valued results that may throw
- * exception. This is the {@code long}-producing primitive specialization of
- * {@link Supplier}.
+ * Represents a supplier of {@code long}-valued results and may throw exception.
+ * This is the {@code long}-producing primitive specialization of
+ * {@link SupplierWithException}.
  *
- * @author borettim
- * @see Supplier
+ * <p>
+ * There is no requirement that a distinct result be returned each time the
+ * supplier is invoked.
+ *
+ * @see SupplierWithException
  * @param <E>
  *            the type of the potential exception of the operation
  */
@@ -45,7 +49,7 @@ public interface LongSupplierWithException<E extends Exception>
 	 *
 	 * @throws E
 	 *             any exception
-	 * @return a boolean
+	 * @return a result
 	 * @see LongSupplier#getAsLong()
 	 */
 	long getAsLong() throws E;
@@ -64,7 +68,7 @@ public interface LongSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts this {@code LongSupplierWithException} to a {@code LongSupplier}
-	 * that convert exception to {@code RuntimeException}.
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked supplier
 	 * @see #unchecked(LongSupplierWithException)
@@ -104,15 +108,17 @@ public interface LongSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongSupplierWithException} to a {@code LongSupplier} that
-	 * convert exception to {@code RuntimeException}. o
+	 * wraps exception to {@code RuntimeException}.
 	 *
 	 * @param supplier
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked supplier
 	 * @see #uncheck()
 	 * @see #unchecked(LongSupplierWithException, Function)
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> LongSupplier unchecked(LongSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).uncheck();
@@ -120,7 +126,7 @@ public interface LongSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongSupplierWithException} to a {@code LongSupplier} that
-	 * convert exception to {@code RuntimeException} by using the provided mapping
+	 * wraps exception to {@code RuntimeException} by using the provided mapping
 	 * function.
 	 *
 	 * @param supplier
@@ -129,14 +135,16 @@ public interface LongSupplierWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked supplier
 	 * @see #uncheck()
 	 * @see #unchecked(LongSupplierWithException)
+	 * @throws NullPointerException
+	 *             if supplier or exceptionMapper is null
 	 */
 	static <E extends Exception> LongSupplier unchecked(LongSupplierWithException<E> supplier,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(supplier, SUPPLIER_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new LongSupplierWithException<E>() {
 
 			@Override
@@ -154,7 +162,7 @@ public interface LongSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongSupplierWithException} to a lifted {@code LongSupplier}
-	 * returning {@code null} in case of exception.
+	 * returning {@code 0} in case of exception.
 	 *
 	 * @param supplier
 	 *            to be lifted
@@ -162,6 +170,8 @@ public interface LongSupplierWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted supplier
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> LongSupplier lifted(LongSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).lift();
@@ -169,7 +179,7 @@ public interface LongSupplierWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongSupplierWithException} to a lifted {@code LongSupplier}
-	 * returning {@code null} in case of exception.
+	 * returning {@code 0} in case of exception.
 	 *
 	 * @param supplier
 	 *            to be lifted
@@ -177,6 +187,8 @@ public interface LongSupplierWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted supplier
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <E extends Exception> LongSupplier ignored(LongSupplierWithException<E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongToDoubleFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongToDoubleFunctionWithException.java
@@ -32,6 +32,14 @@ import java.util.function.Supplier;
  * exception and produces a double-valued result. This is the
  * {@code long}-to-{@code double} primitive specialization for
  * {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsDouble(long) double applyAsDouble(long value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code LongToDoubleFunction}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code LongToDoubleFunction}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code LongToDoubleFunction}</li>
+ * </ul>
  *
  * @see LongToDoubleFunction
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongToDoubleFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongToDoubleFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,10 +28,11 @@ import java.util.function.LongToDoubleFunction;
 import java.util.function.Supplier;
 
 /**
- * Represents a predicate (boolean-valued function) of one argument and may
- * throw an exception.
+ * Represents a function that accepts a long-valued argument, may throw an
+ * exception and produces a double-valued result. This is the
+ * {@code long}-to-{@code double} primitive specialization for
+ * {@link FunctionWithException}.
  *
- * @author borettim
  * @see LongToDoubleFunction
  * @param <E>
  *            the type of the potential exception of the function
@@ -40,22 +42,22 @@ public interface LongToDoubleFunctionWithException<E extends Exception>
 		extends PrimitiveReturnExceptionHandlerSupport<LongToDoubleFunction> {
 
 	/**
-	 * Evaluates this predicate on the given argument.
+	 * Applies this function to the given argument.
 	 *
-	 * @param t
-	 *            the input argument
-	 * @return the result
+	 * @param value
+	 *            the function argument
+	 * @return the function result
 	 * @throws E
 	 *             any exception
 	 * @see LongToDoubleFunction#applyAsDouble(long)
 	 */
-	double applyAsDouble(long t) throws E;
+	double applyAsDouble(long value) throws E;
 
 	@Override
 	default LongToDoubleFunction uncheckOrIgnore(boolean uncheck) {
-		return t -> {
+		return value -> {
 			try {
-				return applyAsDouble(t);
+				return applyAsDouble(value);
 			} catch (Exception e) {
 				PrimitiveReturnExceptionHandlerSupport.handleException(uncheck, e, exceptionMapper());
 				return 0;
@@ -64,11 +66,11 @@ public interface LongToDoubleFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts this {@code DoubleToIntFunctionWithException} to a
-	 * {@code LongToDoubleFunction} that convert exception to
+	 * Converts this {@code LongToDoubleFunctionWithException} to a
+	 * {@code LongToDoubleFunction} that wraps exception to
 	 * {@code RuntimeException}.
 	 *
-	 * @return the unchecked predicate
+	 * @return the unchecked function
 	 * @see #unchecked(LongToDoubleFunctionWithException)
 	 * @see #unchecked(LongToDoubleFunctionWithException, Function)
 	 */
@@ -78,10 +80,10 @@ public interface LongToDoubleFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts this {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code LongToDoubleFunction} returning {@code null} in case of exception.
+	 * Converts this {@code LongToDoubleFunctionWithException} to a lifted
+	 * {@code LongToDoubleFunction} returning {@code 0} in case of exception.
 	 *
-	 * @return the predicate that ignore error (return false in this case)
+	 * @return the function that ignore error (return 0 in this case)
 	 * @see #ignored(LongToDoubleFunctionWithException)
 	 */
 	@Override
@@ -90,13 +92,13 @@ public interface LongToDoubleFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <E extends Exception> LongToDoubleFunctionWithException<E> failing(Supplier<E> exceptionBuilder) {
 		return t -> {
@@ -105,26 +107,28 @@ public interface LongToDoubleFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a
-	 * {@code LongToDoubleFunction} that convert exception to
+	 * Converts a {@code LongToDoubleFunctionWithException} to a
+	 * {@code LongToDoubleFunction} that wraps exception to
 	 * {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(LongToDoubleFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> LongToDoubleFunction unchecked(LongToDoubleFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a
-	 * {@code LongToDoubleFunction} that convert exception to
-	 * {@code RuntimeException} by using the provided mapping function.
+	 * Converts a {@code LongToDoubleFunctionWithException} to a
+	 * {@code LongToDoubleFunction} that wraps exception to {@code RuntimeException}
+	 * by using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
@@ -132,19 +136,21 @@ public interface LongToDoubleFunctionWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(LongToDoubleFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> LongToDoubleFunction unchecked(LongToDoubleFunctionWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new LongToDoubleFunctionWithException<E>() {
 
 			@Override
-			public double applyAsDouble(long t) throws E {
-				return function.applyAsDouble(t);
+			public double applyAsDouble(long value) throws E {
+				return function.applyAsDouble(value);
 			}
 
 			@Override
@@ -156,8 +162,8 @@ public interface LongToDoubleFunctionWithException<E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code LongToDoubleFunction} returning {@code null} in case of exception.
+	 * Converts a {@code LongToDoubleFunctionWithException} to a lifted
+	 * {@code LongToDoubleFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -165,14 +171,16 @@ public interface LongToDoubleFunctionWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> LongToDoubleFunction lifted(LongToDoubleFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
 	}
 
 	/**
-	 * Converts a {@code DoubleToIntFunctionWithException} to a lifted
-	 * {@code LongToDoubleFunction} returning {@code null} in case of exception.
+	 * Converts a {@code LongToDoubleFunctionWithException} to a lifted
+	 * {@code LongToDoubleFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -180,6 +188,8 @@ public interface LongToDoubleFunctionWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> LongToDoubleFunction ignored(LongToDoubleFunctionWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongToIntFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongToIntFunctionWithException.java
@@ -32,6 +32,14 @@ import java.util.function.Supplier;
  * exception and produces an int-valued result. This is the
  * {@code long}-to-{@code int} primitive specialization for
  * {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsInt(long) int applyAsInt(long value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code LongToIntFunction}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code LongToIntFunction}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code LongToIntFunction}</li>
+ * </ul>
  *
  * @see LongToIntFunction
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongUnaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongUnaryOperatorWithException.java
@@ -32,6 +32,14 @@ import java.util.function.Supplier;
  * exception and that produces a {@code long}-valued result. This is the
  * primitive type specialization of {@link UnaryOperatorWithException} for
  * {@code long}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsLong(long) long applyAsLong(long operand) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code LongUnaryOperator}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code LongUnaryOperator}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code LongUnaryOperator}</li>
+ * </ul>
  *
  * @see LongUnaryOperator
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/LongUnaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/LongUnaryOperatorWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -160,15 +161,17 @@ public interface LongUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongUnaryOperatorException} to a {@code LongUnaryOperator}
-	 * that convert exception to {@code RuntimeException}.
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(LongUnaryOperatorWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> LongUnaryOperator unchecked(LongUnaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -176,8 +179,8 @@ public interface LongUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongUnaryOperatorWithException} to a
-	 * {@code LongUnaryOperator} that convert exception to {@code RuntimeException}
-	 * by using the provided mapping function.
+	 * {@code LongUnaryOperator} that wraps exception to {@code RuntimeException} by
+	 * using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
@@ -185,14 +188,16 @@ public interface LongUnaryOperatorWithException<E extends Exception>
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(LongUnaryOperatorWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <E extends Exception> LongUnaryOperator unchecked(LongUnaryOperatorWithException<E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new LongUnaryOperatorWithException<E>() {
 
 			@Override
@@ -210,7 +215,7 @@ public interface LongUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongUnaryOperatorWithException} to a lifted
-	 * {@code LongUnaryOperator} using {@code Optional} as return value.
+	 * {@code LongUnaryOperator} using {@code 0} as return value in case of error.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -218,6 +223,8 @@ public interface LongUnaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> LongUnaryOperator lifted(LongUnaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
@@ -225,7 +232,7 @@ public interface LongUnaryOperatorWithException<E extends Exception>
 
 	/**
 	 * Converts a {@code LongUnaryOperatorWithException} to a lifted
-	 * {@code LongUnaryOperator} returning {@code null} in case of exception.
+	 * {@code LongUnaryOperator} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -233,6 +240,8 @@ public interface LongUnaryOperatorWithException<E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <E extends Exception> LongUnaryOperator ignored(LongUnaryOperatorWithException<E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/NoReturnExceptionHandlerSupport.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/NoReturnExceptionHandlerSupport.java
@@ -27,29 +27,57 @@ import java.util.function.Consumer;
 
 /**
  * Root interface to support global operations related to exception handling for
- * function interface without return value.
+ * functional interface without return value.
  *
- * @author borettim
  * @param <F>
- *            the type of the java standard function interface
+ *            the type of the java standard functional interface. For example,
+ *            {@code Consumer<T>}. The same functional interface is also used
+ *            for the lifted and ignored version.
  */
 public interface NoReturnExceptionHandlerSupport<F> extends ExceptionHandlerSupport<F, F> {
 
 	/**
-	 * Converts this function interface to the corresponding one in java and wrap
-	 * exception.
+	 * Converts this functional interface to the corresponding one in java and wrap
+	 * exception using {@link #exceptionMapper()}.
+	 * <p>
+	 * Conceptually, the exception encapsulation is done in the following way :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		// do the underlying functional interface action and return result if
+	 * 		// applicable
+	 * 	} catch (Exception e) {
+	 * 		throw new exceptionMapper().apply(e);
+	 * 	}
+	 * }
+	 * </pre>
 	 *
 	 * @return the unchecked operation
+	 * @see #lift()
+	 * @see #ignore()
 	 */
 	@Override
 	F uncheck();
 
 	/**
-	 * Converts this function interface to a lifted one.
+	 * Converts this functional interface to a lifted one.
 	 * <p>
-	 * This method is identical to {@link #ignore()}
+	 * The concept is :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		// do nothing
+	 * 	}
+	 * }
+	 * </pre>
 	 *
 	 * @return the lifted function
+	 * @see #uncheck()
+	 * @see #ignore()
 	 */
 	@Override
 	default F lift() {
@@ -57,10 +85,23 @@ public interface NoReturnExceptionHandlerSupport<F> extends ExceptionHandlerSupp
 	}
 
 	/**
-	 * Converts this function interface to the corresponding <i>lifted</i> java
-	 * standard interface ignoring exception.
+	 * Converts this functional interface to a lifted one.
+	 * <p>
+	 * The concept is :
 	 *
-	 * @return the operation that ignore error
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		// do nothing
+	 * 	}
+	 * }
+	 * </pre>
+	 *
+	 * @return the lifted function
+	 * @see #uncheck()
+	 * @see #ignore()
 	 */
 	@Override
 	F ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/ObjDoubleConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ObjDoubleConsumerWithException.java
@@ -34,6 +34,14 @@ import java.util.function.Supplier;
  * {@link BiConsumerWithException}. Unlike most other functional interfaces,
  * {@code ObjDoubleConsumerWithException} is expected to operate via
  * side-effects.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #accept(Object, double) void accept(T t, double value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code ObjDoubleConsumer<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code ObjDoubleConsumer<T>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code ObjDoubleConsumer<T>}</li>
+ * </ul>
  *
  * @see ObjDoubleConsumer
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ObjDoubleConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ObjDoubleConsumerWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.OPERATION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,14 +28,16 @@ import java.util.function.ObjDoubleConsumer;
 import java.util.function.Supplier;
 
 /**
- * Represents an operation that accepts two input arguments and returns no
- * result and may throw exception. Unlike most other functional interfaces,
- * {@code Consumer} is expected to operate via side-effects.
+ * Represents an operation that accepts an object-valued and a
+ * {@code double}-valued argument, and returns no result. This is the
+ * {@code (reference, double)} specialization of
+ * {@link BiConsumerWithException}. Unlike most other functional interfaces,
+ * {@code ObjDoubleConsumerWithException} is expected to operate via
+ * side-effects.
  *
- * @author borettim
  * @see ObjDoubleConsumer
  * @param <T>
- *            the type of the input to the operation
+ *            the type of the object argument to the operation
  * @param <E>
  *            the type of the potential exception of the operation
  */
@@ -47,17 +50,17 @@ public interface ObjDoubleConsumerWithException<T, E extends Exception>
 	 *
 	 * @param t
 	 *            the first input argument
-	 * @param u
+	 * @param value
 	 *            the second input argument
 	 * @throws E
 	 *             any exception
 	 * @see ObjDoubleConsumer#accept(Object,double)
 	 */
-	void accept(T t, double u) throws E;
+	void accept(T t, double value) throws E;
 
 	/**
 	 * Converts this {@code ObjLongConsumerWithException} to a
-	 * {@code ObjDoubleConsumer} that convert exception to {@code RuntimeException}.
+	 * {@code ObjDoubleConsumer} that wraps exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked operation
 	 * @see #unchecked(ObjDoubleConsumerWithException)
@@ -65,7 +68,7 @@ public interface ObjDoubleConsumerWithException<T, E extends Exception>
 	 */
 	@Override
 	default ObjDoubleConsumer<T> uncheck() {
-		return (t, u) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, u), throwingHandler());
+		return (t, value) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, value), throwingHandler());
 	}
 
 	/**
@@ -77,7 +80,7 @@ public interface ObjDoubleConsumerWithException<T, E extends Exception>
 	 */
 	@Override
 	default ObjDoubleConsumer<T> ignore() {
-		return (t, u) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, u), notThrowingHandler());
+		return (t, value) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, value), notThrowingHandler());
 	}
 
 	/**
@@ -86,7 +89,7 @@ public interface ObjDoubleConsumerWithException<T, E extends Exception>
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the exception
 	 * @return an operation that always throw exception
@@ -98,18 +101,20 @@ public interface ObjDoubleConsumerWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiConsumerWithException} to a {@code Consumer} that convert
-	 * exception to {@code RuntimeException}.
+	 * Converts a {@code ObjDoubleConsumerWithException} to a
+	 * {@code ObjDoubleConsumer} that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param operation
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(ObjDoubleConsumerWithException, Function)
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> ObjDoubleConsumer<T> unchecked(ObjDoubleConsumerWithException<T, E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).uncheck();
@@ -117,30 +122,32 @@ public interface ObjDoubleConsumerWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ObjLongConsumerWithException} to a
-	 * {@code ObjDoubleConsumer} that convert exception to {@code RuntimeException}
-	 * by using the provided mapping function.
+	 * {@code ObjDoubleConsumer} that wraps exception to {@code RuntimeException} by
+	 * using the provided mapping function.
 	 *
 	 * @param operation
 	 *            the be unchecked
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(ObjDoubleConsumerWithException)
+	 * @throws NullPointerException
+	 *             if operation or exceptionMapper is null
 	 */
 	static <T, E extends Exception> ObjDoubleConsumer<T> unchecked(ObjDoubleConsumerWithException<T, E> operation,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(operation, OPERATION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new ObjDoubleConsumerWithException<T, E>() {
 
 			@Override
-			public void accept(T t, double u) throws E {
-				operation.accept(t, u);
+			public void accept(T t, double value) throws E {
+				operation.accept(t, value);
 			}
 
 			@Override
@@ -153,16 +160,18 @@ public interface ObjDoubleConsumerWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ObjLongConsumerWithException} to a lifted
-	 * {@code ObjDoubleConsumer} returning {@code null} in case of exception.
+	 * {@code ObjDoubleConsumer} ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> ObjDoubleConsumer<T> lifted(ObjDoubleConsumerWithException<T, E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).lift();
@@ -170,16 +179,18 @@ public interface ObjDoubleConsumerWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ObjLongConsumerWithException} to a lifted
-	 * {@code ObjDoubleConsumer} returning {@code null} in case of exception.
+	 * {@code ObjDoubleConsumer} ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> ObjDoubleConsumer<T> ignored(ObjDoubleConsumerWithException<T, E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).ignore();
@@ -192,10 +203,12 @@ public interface ObjDoubleConsumerWithException<T, E extends Exception>
 	 * @param operation
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the function
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> BiConsumerWithException<T, Double, E> asBiConsumer(
 			ObjDoubleConsumerWithException<T, E> operation) {

--- a/src/main/java/ch/powerunit/extensions/exceptions/ObjIntConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ObjIntConsumerWithException.java
@@ -33,6 +33,14 @@ import java.util.function.Supplier;
  * {@code (reference, int)} specialization of {@link BiConsumerWithException}.
  * Unlike most other functional interfaces, {@code ObjIntConsumer} is expected
  * to operate via side-effects.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #accept(Object, int) void accept(T t, int value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code ObjIntConsumer<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code ObjIntConsumer<T>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code ObjIntConsumer<T>}</li>
+ * </ul>
  *
  * @see ObjIntConsumer
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ObjIntConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ObjIntConsumerWithException.java
@@ -19,23 +19,24 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.OPERATION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.ObjIntConsumer;
 import java.util.function.Supplier;
 
 /**
- * Represents an operation that accepts two input arguments and returns no
- * result and may throw exception. Unlike most other functional interfaces,
- * {@code Consumer} is expected to operate via side-effects.
+ * Represents an operation that accepts an object-valued and a
+ * {@code int}-valued argument, and returns no result. This is the
+ * {@code (reference, int)} specialization of {@link BiConsumerWithException}.
+ * Unlike most other functional interfaces, {@code ObjIntConsumer} is expected
+ * to operate via side-effects.
  *
- * @author borettim
- * @see Consumer
+ * @see ObjIntConsumer
  * @param <T>
- *            the type of the input to the operation
+ *            the type of the object argument to the operation
  * @param <E>
  *            the type of the potential exception of the operation
  */
@@ -48,17 +49,17 @@ public interface ObjIntConsumerWithException<T, E extends Exception>
 	 *
 	 * @param t
 	 *            the first input argument
-	 * @param u
+	 * @param value
 	 *            the second input argument
 	 * @throws E
 	 *             any exception
 	 * @see ObjIntConsumer#accept(Object,int)
 	 */
-	void accept(T t, int u) throws E;
+	void accept(T t, int value) throws E;
 
 	/**
 	 * Converts this {@code ObjIntConsumerWithException} to a {@code ObjIntConsumer}
-	 * that convert exception to {@code RuntimeException}.
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked operation
 	 * @see #unchecked(ObjIntConsumerWithException)
@@ -66,7 +67,7 @@ public interface ObjIntConsumerWithException<T, E extends Exception>
 	 */
 	@Override
 	default ObjIntConsumer<T> uncheck() {
-		return (t, u) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, u), throwingHandler());
+		return (t, value) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, value), throwingHandler());
 	}
 
 	/**
@@ -78,7 +79,7 @@ public interface ObjIntConsumerWithException<T, E extends Exception>
 	 */
 	@Override
 	default ObjIntConsumer<T> ignore() {
-		return (t, u) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, u), notThrowingHandler());
+		return (t, value) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, value), notThrowingHandler());
 	}
 
 	/**
@@ -87,7 +88,7 @@ public interface ObjIntConsumerWithException<T, E extends Exception>
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the exception
 	 * @return an operation that always throw exception
@@ -99,18 +100,20 @@ public interface ObjIntConsumerWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiConsumerWithException} to a {@code Consumer} that convert
-	 * exception to {@code RuntimeException}.
+	 * Converts a {@code ObjIntConsumerWithException} to a {@code ObjIntConsumer}
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param operation
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(ObjIntConsumerWithException, Function)
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> ObjIntConsumer<T> unchecked(ObjIntConsumerWithException<T, E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).uncheck();
@@ -118,7 +121,7 @@ public interface ObjIntConsumerWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ObjIntConsumerWithException} to a {@code ObjIntConsumer}
-	 * that convert exception to {@code RuntimeException} by using the provided
+	 * that wraps exception to {@code RuntimeException} by using the provided
 	 * mapping function.
 	 *
 	 * @param operation
@@ -126,22 +129,24 @@ public interface ObjIntConsumerWithException<T, E extends Exception>
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(ObjIntConsumerWithException)
+	 * @throws NullPointerException
+	 *             if operation or exceptionMapper is null
 	 */
 	static <T, E extends Exception> ObjIntConsumer<T> unchecked(ObjIntConsumerWithException<T, E> operation,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(operation, OPERATION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new ObjIntConsumerWithException<T, E>() {
 
 			@Override
-			public void accept(T t, int u) throws E {
-				operation.accept(t, u);
+			public void accept(T t, int value) throws E {
+				operation.accept(t, value);
 			}
 
 			@Override
@@ -154,16 +159,18 @@ public interface ObjIntConsumerWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ObjIntConsumerWithException} to a lifted
-	 * {@code ObjIntConsumer} returning {@code null} in case of exception.
+	 * {@code ObjIntConsumer} ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> ObjIntConsumer<T> lifted(ObjIntConsumerWithException<T, E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).lift();
@@ -171,16 +178,18 @@ public interface ObjIntConsumerWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ObjIntConsumerWithException} to a lifted
-	 * {@code ObjIntConsumer} returning {@code null} in case of exception.
+	 * {@code ObjIntConsumer} ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> ObjIntConsumer<T> ignored(ObjIntConsumerWithException<T, E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).ignore();
@@ -193,10 +202,12 @@ public interface ObjIntConsumerWithException<T, E extends Exception>
 	 * @param operation
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the function
+	 * @return the bi consumer
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> BiConsumerWithException<T, Integer, E> asBiConsumer(
 			ObjIntConsumerWithException<T, E> operation) {

--- a/src/main/java/ch/powerunit/extensions/exceptions/ObjLongConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ObjLongConsumerWithException.java
@@ -33,6 +33,14 @@ import java.util.function.Supplier;
  * {@code (reference, long)} specialization of {@link BiConsumerWithException}.
  * Unlike most other functional interfaces, {@code ObjLongConsumerWithException}
  * is expected to operate via side-effects.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #accept(Object, long) void accept(T t, long value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code ObjLongConsumer<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code ObjLongConsumer<T>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code ObjLongConsumer<T>}</li>
+ * </ul>
  *
  * @see ObjLongConsumer
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ObjLongConsumerWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ObjLongConsumerWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.OPERATION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,14 +28,15 @@ import java.util.function.ObjLongConsumer;
 import java.util.function.Supplier;
 
 /**
- * Represents an operation that accepts two input arguments and returns no
- * result and may throw exception. Unlike most other functional interfaces,
- * {@code Consumer} is expected to operate via side-effects.
+ * Represents an operation that accepts an object-valued and a
+ * {@code long}-valued argument, and returns no result. This is the
+ * {@code (reference, long)} specialization of {@link BiConsumerWithException}.
+ * Unlike most other functional interfaces, {@code ObjLongConsumerWithException}
+ * is expected to operate via side-effects.
  *
- * @author borettim
  * @see ObjLongConsumer
  * @param <T>
- *            the type of the input to the operation
+ *            the type of the object argument to the operation
  * @param <E>
  *            the type of the potential exception of the operation
  */
@@ -47,17 +49,17 @@ public interface ObjLongConsumerWithException<T, E extends Exception>
 	 *
 	 * @param t
 	 *            the first input argument
-	 * @param u
+	 * @param value
 	 *            the second input argument
 	 * @throws E
 	 *             any exception
 	 * @see ObjLongConsumer#accept(Object,long)
 	 */
-	void accept(T t, long u) throws E;
+	void accept(T t, long value) throws E;
 
 	/**
 	 * Converts this {@code ObjLongConsumerWithException} to a
-	 * {@code ObjLongConsumer} that convert exception to {@code RuntimeException}.
+	 * {@code ObjLongConsumer} that wraps exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked operation
 	 * @see #unchecked(ObjLongConsumerWithException)
@@ -65,7 +67,7 @@ public interface ObjLongConsumerWithException<T, E extends Exception>
 	 */
 	@Override
 	default ObjLongConsumer<T> uncheck() {
-		return (t, u) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, u), throwingHandler());
+		return (t, value) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, value), throwingHandler());
 	}
 
 	/**
@@ -77,7 +79,7 @@ public interface ObjLongConsumerWithException<T, E extends Exception>
 	 */
 	@Override
 	default ObjLongConsumer<T> ignore() {
-		return (t, u) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, u), notThrowingHandler());
+		return (t, value) -> NoReturnExceptionHandlerSupport.unchecked(() -> accept(t, value), notThrowingHandler());
 	}
 
 	/**
@@ -86,7 +88,7 @@ public interface ObjLongConsumerWithException<T, E extends Exception>
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the exception
 	 * @return an operation that always throw exception
@@ -98,18 +100,20 @@ public interface ObjLongConsumerWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiConsumerWithException} to a {@code Consumer} that convert
-	 * exception to {@code RuntimeException}.
+	 * Converts a {@code ObjLongConsumerWithException} to a {@code ObjLongConsumer}
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param operation
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(ObjLongConsumerWithException, Function)
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> ObjLongConsumer<T> unchecked(ObjLongConsumerWithException<T, E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).uncheck();
@@ -117,7 +121,7 @@ public interface ObjLongConsumerWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ObjLongConsumerWithException} to a {@code ObjLongConsumer}
-	 * that convert exception to {@code RuntimeException} by using the provided
+	 * that wraps exception to {@code RuntimeException} by using the provided
 	 * mapping function.
 	 *
 	 * @param operation
@@ -125,22 +129,24 @@ public interface ObjLongConsumerWithException<T, E extends Exception>
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked operation
 	 * @see #uncheck()
 	 * @see #unchecked(ObjLongConsumerWithException)
+	 * @throws NullPointerException
+	 *             if operation or exceptionMapper is null
 	 */
 	static <T, E extends Exception> ObjLongConsumer<T> unchecked(ObjLongConsumerWithException<T, E> operation,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(operation, OPERATION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new ObjLongConsumerWithException<T, E>() {
 
 			@Override
-			public void accept(T t, long u) throws E {
-				operation.accept(t, u);
+			public void accept(T t, long value) throws E {
+				operation.accept(t, value);
 			}
 
 			@Override
@@ -153,16 +159,18 @@ public interface ObjLongConsumerWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ObjLongConsumerWithException} to a lifted
-	 * {@code ObjLongConsumer} returning {@code null} in case of exception.
+	 * {@code ObjLongConsumer} ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> ObjLongConsumer<T> lifted(ObjLongConsumerWithException<T, E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).lift();
@@ -170,16 +178,18 @@ public interface ObjLongConsumerWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ObjLongConsumerWithException} to a lifted
-	 * {@code ObjLongConsumer} returning {@code null} in case of exception.
+	 * {@code ObjLongConsumer} ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> ObjLongConsumer<T> ignored(ObjLongConsumerWithException<T, E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).ignore();
@@ -192,10 +202,12 @@ public interface ObjLongConsumerWithException<T, E extends Exception>
 	 * @param operation
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the operation
+	 *            the type of the object argument to the operation
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the function
+	 * @return the bi consumer
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <T, E extends Exception> BiConsumerWithException<T, Long, E> asBiConsumer(
 			ObjLongConsumerWithException<T, E> operation) {

--- a/src/main/java/ch/powerunit/extensions/exceptions/ObjectReturnExceptionHandlerSupport.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ObjectReturnExceptionHandlerSupport.java
@@ -29,42 +29,84 @@ import java.util.function.Function;
 
 /**
  * Root interface to support global operations related to exception handling for
- * function interface without return value.
+ * functional interface returning Object result.
  *
- * @author borettim
  * @param <F>
- *            the type of the java standard function interface
+ *            the type of the java standard functional interface. For example,
+ *            {@code Function<T,R>}.
  * @param <L>
- *            the type of the lifted function interface
+ *            the type of the lifted functional interface. For example,
+ *            {@code Function<T,Optional<R>>}.
  * @param <T>
- *            the type of the return type
+ *            the type of the return type of the Functional interface.
  */
 public interface ObjectReturnExceptionHandlerSupport<F, L, T> extends ExceptionHandlerSupport<F, L> {
 
 	/**
-	 * Converts this function interface to the corresponding one in java and wrap
-	 * exception.
+	 * Converts this functional interface to the corresponding one in java and wrap
+	 * exception using {@link #exceptionMapper()}.
+	 * <p>
+	 * Conceptually, the exception encapsulation is done in the following way :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		return realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		throw new exceptionMapper().apply(e);
+	 * 	}
+	 * }
+	 * </pre>
 	 *
 	 * @return the unchecked operation
+	 * @see #lift()
+	 * @see #ignore()
 	 */
 	@Override
 	F uncheck();
 
 	/**
-	 * Converts this function interface to a lifted one.
+	 * Converts this functional interface to a lifted one. The lifted version return
+	 * an Optional of the original return type.
 	 * <p>
-	 * This method is identical to {@link #ignore()}
+	 * Conceptually, this is done by :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		return Optional.ofNullable(realaction(xxx));
+	 * 	} catch (Exception e) {
+	 * 		return Optional.empty();
+	 * 	}
+	 * }
+	 * </pre>
 	 *
 	 * @return the lifted function
+	 * @see #uncheck()
+	 * @see #ignore()
 	 */
 	@Override
 	L lift();
 
 	/**
-	 * Converts this function interface to the corresponding <i>lifted</i> java
-	 * standard interface ignoring exception.
+	 * Converts this functional interface to the corresponding java standard
+	 * functional interface returning a null in case of error.
+	 * <p>
+	 * The principle is :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		return realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		return null;
+	 * 	}
+	 * }
+	 * </pre>
 	 *
 	 * @return the operation that ignore error
+	 * @see #uncheck()
+	 * @see #lift()
 	 */
 	@Override
 	F ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/PredicateWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/PredicateWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.PREDICATE_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -30,7 +31,6 @@ import java.util.function.Supplier;
  * Represents a predicate (boolean-valued function) of one argument and may
  * throw an exception.
  *
- * @author borettim
  * @see Predicate
  * @param <T>
  *            the type of the input to the predicate
@@ -108,11 +108,13 @@ public interface PredicateWithException<T, E extends Exception>
 	 * @param predicate
 	 *            to be negate
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the predicate
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the negated predicate
 	 * @see #negate()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <T, E extends Exception> PredicateWithException<T, E> negate(PredicateWithException<T, E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).negate();
@@ -148,7 +150,7 @@ public interface PredicateWithException<T, E extends Exception>
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the predicate
 	 * @param <E>
 	 *            the type of the exception
 	 * @return a predicate that always throw exception
@@ -160,25 +162,27 @@ public interface PredicateWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code PredicateWithException} to a {@code Predicate} that convert
+	 * Converts a {@code PredicateWithException} to a {@code Predicate} that wraps
 	 * exception to {@code RuntimeException}.
 	 *
 	 * @param predicate
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the predicate
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(PredicateWithException, Function)
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <T, E extends Exception> Predicate<T> unchecked(PredicateWithException<T, E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code PredicateWithException} to a {@code Predicate} that convert
+	 * Converts a {@code PredicateWithException} to a {@code Predicate} that wraps
 	 * exception to {@code RuntimeException} by using the provided mapping function.
 	 *
 	 * @param predicate
@@ -192,11 +196,13 @@ public interface PredicateWithException<T, E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(PredicateWithException)
+	 * @throws NullPointerException
+	 *             if predicate or exceptionMapper is null
 	 */
 	static <T, E extends Exception> Predicate<T> unchecked(PredicateWithException<T, E> predicate,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(predicate, PREDICATE_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new PredicateWithException<T, E>() {
 
 			@Override
@@ -214,16 +220,18 @@ public interface PredicateWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code PredicateWithException} to a lifted {@code Predicate}
-	 * returning {@code null} in case of exception.
+	 * returning {@code false} in case of exception.
 	 *
 	 * @param predicate
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the predicate
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the lifted function
+	 * @return the lifted predicate
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <T, E extends Exception> Predicate<T> lifted(PredicateWithException<T, E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).lift();
@@ -231,16 +239,18 @@ public interface PredicateWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code PredicateWithException} to a lifted {@code Predicate}
-	 * returning {@code null} in case of exception.
+	 * returning {@code false} in case of exception.
 	 *
 	 * @param predicate
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the predicate
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the lifted function
+	 * @return the lifted predicate
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if predicate is null
 	 */
 	static <T, E extends Exception> Predicate<T> ignored(PredicateWithException<T, E> predicate) {
 		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/PredicateWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/PredicateWithException.java
@@ -30,6 +30,14 @@ import java.util.function.Supplier;
 /**
  * Represents a predicate (boolean-valued function) of one argument and may
  * throw an exception.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #test(Object) boolean test(T t) throws E}</b>&nbsp;-&nbsp;The
+ * functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code Predicate<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code Predicate<T>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code Predicate<T>}</li>
+ * </ul>
  *
  * @see Predicate
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/PrimitiveReturnExceptionHandlerSupport.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/PrimitiveReturnExceptionHandlerSupport.java
@@ -23,19 +23,34 @@ import java.util.function.Function;
 
 /**
  * Root interface to support global operations related to exception handling for
- * function interface with primitive return value.
+ * functional interface with primitive return value.
  *
- * @author borettim
  * @param <F>
- *            the type of the java standard function interface
+ *            the type of the java standard functional interface. For example,
+ *            {@code Predicate<T>}. The same functional interface is also used
+ *            for the lifted and ignored version.
  */
 public interface PrimitiveReturnExceptionHandlerSupport<F> extends ExceptionHandlerSupport<F, F> {
 
 	/**
-	 * Converts this function interface to the corresponding one in java and wrap
-	 * exception.
+	 * Converts this functional interface to the corresponding one in java and wrap
+	 * exception using {@link #exceptionMapper()}.
+	 * <p>
+	 * Conceptually, the exception encapsulation is done in the following way :
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		return realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		throw new exceptionMapper().apply(e);
+	 * 	}
+	 * }
+	 * </pre>
 	 *
 	 * @return the unchecked operation
+	 * @see #lift()
+	 * @see #ignore()
 	 */
 	@Override
 	default F uncheck() {
@@ -43,11 +58,24 @@ public interface PrimitiveReturnExceptionHandlerSupport<F> extends ExceptionHand
 	}
 
 	/**
-	 * Converts this function interface to a lifted one.
+	 * Converts this functional interface to a lifted one. A lifted version return
+	 * the same type as the original one, with a default value.
 	 * <p>
-	 * This method is identical to {@link #ignore()}
+	 * The concept is
+	 *
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		return realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		return defaultValue;
+	 * 	}
+	 * }
+	 * </pre>
 	 *
 	 * @return the lifted function
+	 * @see #uncheck()
+	 * @see #ignore()
 	 */
 	@Override
 	default F lift() {
@@ -55,10 +83,24 @@ public interface PrimitiveReturnExceptionHandlerSupport<F> extends ExceptionHand
 	}
 
 	/**
-	 * Converts this function interface to the corresponding <i>lifted</i> java
-	 * standard interface ignoring exception.
+	 * Converts this functional interface to a lifted one. A lifted version return
+	 * the same type as the original one, with a default value.
+	 * <p>
+	 * The concept is
 	 *
-	 * @return the operation that ignore error
+	 * <pre>
+	 * (xxx) -&gt; {
+	 * 	try {
+	 * 		return realaction(xxx);
+	 * 	} catch (Exception e) {
+	 * 		return defaultValue;
+	 * 	}
+	 * }
+	 * </pre>
+	 *
+	 * @return the lifted function
+	 * @see #uncheck()
+	 * @see #lift()
 	 */
 	@Override
 	default F ignore() {
@@ -66,7 +108,7 @@ public interface PrimitiveReturnExceptionHandlerSupport<F> extends ExceptionHand
 	}
 
 	/**
-	 * Uncheck or ignore, depending on the param.
+	 * Used internally to implements the ignore or uncheck operation.
 	 *
 	 * @param uncheck
 	 *            create unchecked version of the function when true, else ignored

--- a/src/main/java/ch/powerunit/extensions/exceptions/RunnableWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/RunnableWithException.java
@@ -30,6 +30,14 @@ import java.util.function.Supplier;
  * Represents an operation that accepts no input argument and returns no result
  * and may throw exception. Unlike most other functional interfaces,
  * {@code RunnableWithException} is expected to operate via side-effects.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #run() void run() throws E}</b>&nbsp;-&nbsp;The functional
+ * method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code Runnable}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code Runnable}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code Runnable}</li>
+ * </ul>
  *
  * @see Runnable
  * @param <E>

--- a/src/main/java/ch/powerunit/extensions/exceptions/RunnableWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/RunnableWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.OPERATION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -26,11 +27,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents an operation that accepts a no input argument and returns no
- * result and may throw exception. Unlike most other functional interfaces,
- * {@code Consumer} is expected to operate via side-effects.
+ * Represents an operation that accepts no input argument and returns no result
+ * and may throw exception. Unlike most other functional interfaces,
+ * {@code RunnableWithException} is expected to operate via side-effects.
  *
- * @author borettim
  * @see Runnable
  * @param <E>
  *            the type of the potential exception of the operation
@@ -48,8 +48,8 @@ public interface RunnableWithException<E extends Exception> extends NoReturnExce
 	void run() throws E;
 
 	/**
-	 * Converts this {@code RunnableWithException} to a {@code Runnable} that
-	 * convert exception to {@code RuntimeException}.
+	 * Converts this {@code RunnableWithException} to a {@code Runnable} that wraps
+	 * exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked operation
 	 * @see #unchecked(RunnableWithException)
@@ -88,7 +88,7 @@ public interface RunnableWithException<E extends Exception> extends NoReturnExce
 	}
 
 	/**
-	 * Converts a {@code RunnableWithException} to a {@code Runnable} that convert
+	 * Converts a {@code RunnableWithException} to a {@code Runnable} that wraps
 	 * exception to {@code RuntimeException}.
 	 *
 	 * @param operation
@@ -98,13 +98,15 @@ public interface RunnableWithException<E extends Exception> extends NoReturnExce
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(RunnableWithException, Function)
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> Runnable unchecked(RunnableWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code RunnableWithException} to a {@code Runnable} that convert
+	 * Converts a {@code RunnableWithException} to a {@code Runnable} that wraps
 	 * exception to {@code RuntimeException} by using the provided mapping function.
 	 *
 	 * @param operation
@@ -116,11 +118,13 @@ public interface RunnableWithException<E extends Exception> extends NoReturnExce
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(RunnableWithException)
+	 * @throws NullPointerException
+	 *             if operation or exceptionMapper is null
 	 */
 	static <E extends Exception> Runnable unchecked(RunnableWithException<E> operation,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(operation, OPERATION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new RunnableWithException<E>() {
 
 			@Override
@@ -138,7 +142,7 @@ public interface RunnableWithException<E extends Exception> extends NoReturnExce
 
 	/**
 	 * Converts a {@code RunnableWithException} to a lifted {@code Runnable}
-	 * returning {@code null} in case of exception.
+	 * ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
@@ -146,6 +150,8 @@ public interface RunnableWithException<E extends Exception> extends NoReturnExce
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> Runnable lifted(RunnableWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).lift();
@@ -153,7 +159,7 @@ public interface RunnableWithException<E extends Exception> extends NoReturnExce
 
 	/**
 	 * Converts a {@code RunnableWithException} to a lifted {@code Runnable}
-	 * returning {@code null} in case of exception.
+	 * ignoring exception.
 	 *
 	 * @param operation
 	 *            to be lifted
@@ -161,6 +167,8 @@ public interface RunnableWithException<E extends Exception> extends NoReturnExce
 	 *            the type of the potential exception
 	 * @return the lifted operation
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if operation is null
 	 */
 	static <E extends Exception> Runnable ignored(RunnableWithException<E> operation) {
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/SupplierWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/SupplierWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.SUPPLIER_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -28,9 +29,12 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents a supplier of results that may throw exception
+ * Represents a supplier of results that may thrown exception.
  *
- * @author borettim
+ * <p>
+ * There is no requirement that a new or distinct result be returned each time
+ * the supplier is invoked.
+ *
  * @see Supplier
  * @param <T>
  *            the type of results supplied by this supplier
@@ -52,8 +56,8 @@ public interface SupplierWithException<T, E extends Exception>
 	T get() throws E;
 
 	/**
-	 * Converts this {@code SupplierWithException} to a {@code Supplier} that
-	 * convert exception to {@code RuntimeException}.
+	 * Converts this {@code SupplierWithException} to a {@code Supplier} that wraps
+	 * exception to {@code RuntimeException}.
 	 *
 	 * @return the unchecked supplier
 	 * @see #unchecked(SupplierWithException)
@@ -118,7 +122,7 @@ public interface SupplierWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code SupplierWithException} to a {@code Supplier} that convert
+	 * Converts a {@code SupplierWithException} to a {@code Supplier} that wraps
 	 * exception to {@code RuntimeException}.
 	 *
 	 * @param supplier
@@ -130,13 +134,15 @@ public interface SupplierWithException<T, E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(SupplierWithException, Function)
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <T, E extends Exception> Supplier<T> unchecked(SupplierWithException<T, E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code SupplierWithException} to a {@code Supplier} that convert
+	 * Converts a {@code SupplierWithException} to a {@code Supplier} that wraps
 	 * exception to {@code RuntimeException} by using the provided mapping function.
 	 *
 	 * @param supplier
@@ -150,11 +156,13 @@ public interface SupplierWithException<T, E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(SupplierWithException)
+	 * @throws NullPointerException
+	 *             if supplier or exceptionMapper is null
 	 */
 	static <T, E extends Exception> Supplier<T> unchecked(SupplierWithException<T, E> supplier,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(supplier, SUPPLIER_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new SupplierWithException<T, E>() {
 
 			@Override
@@ -182,6 +190,8 @@ public interface SupplierWithException<T, E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <T, E extends Exception> Supplier<Optional<T>> lifted(SupplierWithException<T, E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).lift();
@@ -199,6 +209,8 @@ public interface SupplierWithException<T, E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted supplier
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <T, E extends Exception> Supplier<T> ignored(SupplierWithException<T, E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).ignore();
@@ -216,6 +228,8 @@ public interface SupplierWithException<T, E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted supplier
 	 * @see #stage()
+	 * @throws NullPointerException
+	 *             if supplier is null
 	 */
 	static <T, E extends Exception> Supplier<CompletionStage<T>> staged(SupplierWithException<T, E> supplier) {
 		return requireNonNull(supplier, SUPPLIER_CANT_BE_NULL).stage();

--- a/src/main/java/ch/powerunit/extensions/exceptions/SupplierWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/SupplierWithException.java
@@ -34,6 +34,14 @@ import java.util.function.Supplier;
  * <p>
  * There is no requirement that a new or distinct result be returned each time
  * the supplier is invoked.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #get() T get() throws E}</b>&nbsp;-&nbsp;The functional
+ * method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code Supplier<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code Supplier<Optional<T>>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code Supplier<T>}</li>
+ * </ul>
  *
  * @see Supplier
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleBiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleBiFunctionWithException.java
@@ -31,6 +31,14 @@ import java.util.function.ToDoubleBiFunction;
  * Represents a function that accepts two arguments, may thrown exception and
  * produces a double-valued result. This is the {@code double}-producing
  * primitive specialization for {@link BiFunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsDouble(Object, Object) double applyAsDouble(T t, U u)
+ * throws E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code ToDoubleBiFunction<T, U>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code ToDoubleBiFunction<T, U>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code ToDoubleBiFunction<T, U>}</li>
+ * </ul>
  *
  * @see ToDoubleBiFunction
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleBiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleBiFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -75,9 +76,9 @@ public interface ToDoubleBiFunctionWithException<T, U, E extends Exception>
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the function
 	 * @param <E>
 	 *            the type of the exception
 	 * @return a predicate that always throw exception
@@ -89,20 +90,22 @@ public interface ToDoubleBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a {@code ToDoubleBiFunction}
-	 * that convert exception to {@code RuntimeException}.
+	 * Converts a {@code ToDoubleBiFunctionWithException} to a
+	 * {@code ToDoubleBiFunction} that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the function
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(ToDoubleBiFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, E extends Exception> ToDoubleBiFunction<T, U> unchecked(
 			ToDoubleBiFunctionWithException<T, U, E> function) {
@@ -110,28 +113,30 @@ public interface ToDoubleBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a {@code ToDoubleBiFunction}
-	 * that convert exception to {@code RuntimeException} by using the provided
-	 * mapping function.
+	 * Converts a {@code ToDoubleBiFunctionWithException} to a
+	 * {@code ToDoubleBiFunction} that wraps exception to {@code RuntimeException}
+	 * by using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the function
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(ToDoubleBiFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exception is null
 	 */
 	static <T, U, E extends Exception> ToDoubleBiFunction<T, U> unchecked(
 			ToDoubleBiFunctionWithException<T, U, E> function, Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new ToDoubleBiFunctionWithException<T, U, E>() {
 
 			@Override
@@ -148,19 +153,21 @@ public interface ToDoubleBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a lifted
-	 * {@code ToDoubleBiFunction} returning {@code null} in case of exception.
+	 * Converts a {@code ToDoubleBiFunctionWithException} to a lifted
+	 * {@code ToDoubleBiFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, E extends Exception> ToDoubleBiFunction<T, U> lifted(
 			ToDoubleBiFunctionWithException<T, U, E> function) {
@@ -168,19 +175,21 @@ public interface ToDoubleBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a lifted
-	 * {@code ToDoubleBiFunction} returning {@code null} in case of exception.
+	 * Converts a {@code ToDoubleBiFunctionWithException} to a lifted
+	 * {@code ToDoubleBiFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, E extends Exception> ToDoubleBiFunction<T, U> ignored(
 			ToDoubleBiFunctionWithException<T, U, E> function) {

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleBiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleBiFunctionWithException.java
@@ -71,7 +71,7 @@ public interface ToDoubleBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
@@ -81,7 +81,7 @@ public interface ToDoubleBiFunctionWithException<T, U, E extends Exception>
 	 *            the type of the second argument the function
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <T, U, E extends Exception> ToDoubleBiFunctionWithException<T, U, E> failing(Supplier<E> exceptionBuilder) {
 		return (t, u) -> {

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleFunctionWithException.java
@@ -31,6 +31,14 @@ import java.util.function.ToDoubleFunction;
  * Represents a function that produces a double-valued result, may throw
  * exception. This is the {@code double}-producing primitive specialization for
  * {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsDouble(Object) double applyAsDouble(T value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code ToDoubleFunction<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code ToDoubleFunction<T>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code ToDoubleFunction<T>}</li>
+ * </ul>
  *
  * @see ToDoubleFunction
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,9 +28,10 @@ import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 
 /**
- * Represents a function of one argument and may throw an exception.
+ * Represents a function that produces a double-valued result, may throw
+ * exception. This is the {@code double}-producing primitive specialization for
+ * {@link FunctionWithException}.
  *
- * @author borettim
  * @see ToDoubleFunction
  * @param <T>
  *            the type of the input to the predicate
@@ -41,17 +43,16 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 		extends PrimitiveReturnExceptionHandlerSupport<ToDoubleFunction<T>> {
 
 	/**
-	 * Evaluates this function on the given argument.
+	 * Applies this function to the given argument.
 	 *
-	 * @param t
-	 *            the input argument
-	 * @return {@code true} if the input argument matches the predicate, otherwise
-	 *         {@code false}
+	 * @param value
+	 *            the function argument
+	 * @return the function result
 	 * @throws E
 	 *             any exception
 	 * @see ToDoubleFunction#applyAsDouble(Object)
 	 */
-	double applyAsDouble(T t) throws E;
+	double applyAsDouble(T value) throws E;
 
 	@Override
 	default ToDoubleFunction<T> uncheckOrIgnore(boolean uncheck) {
@@ -66,7 +67,7 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
@@ -83,8 +84,8 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code ToLongFunctionException} to a {@code ToDoubleFunction} that
-	 * convert exception to {@code RuntimeException}.
+	 * Converts a {@code ToDoubleFunctionException} to a {@code ToDoubleFunction}
+	 * that convert exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
@@ -95,15 +96,17 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(ToDoubleFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> ToDoubleFunction<T> unchecked(ToDoubleFunctionWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code ToLongFunctionWithException} to a {@code ToDoubleFunction}
-	 * that convert exception to {@code RuntimeException} by using the provided
-	 * mapping function.
+	 * Converts a {@code ToDoubleFunctionWithException} to a
+	 * {@code ToDoubleFunction} that convert exception to {@code RuntimeException}
+	 * by using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
@@ -113,19 +116,21 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	 *            the type of the input object to the function
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(ToDoubleFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <T, E extends Exception> ToDoubleFunction<T> unchecked(ToDoubleFunctionWithException<T, E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new ToDoubleFunctionWithException<T, E>() {
 
 			@Override
-			public double applyAsDouble(T t) throws E {
-				return function.applyAsDouble(t);
+			public double applyAsDouble(T value) throws E {
+				return function.applyAsDouble(value);
 			}
 
 			@Override
@@ -137,8 +142,8 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code ToLongFunctionWithException} to a lifted
-	 * {@code ToDoubleFunction} returning {@code null} in case of exception.
+	 * Converts a {@code ToDoubleFunctionWithException} to a lifted
+	 * {@code ToDoubleFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -148,14 +153,16 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> ToDoubleFunction<T> lifted(ToDoubleFunctionWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
 	}
 
 	/**
-	 * Converts a {@code ToLongFunctionWithException} to a lifted
-	 * {@code ToDoubleFunction} returning {@code null} in case of exception.
+	 * Converts a {@code ToDoubleFunctionWithException} to a lifted
+	 * {@code ToDoubleFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -165,6 +172,8 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> ToDoubleFunction<T> ignored(ToDoubleFunctionWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToDoubleFunctionWithException.java
@@ -34,7 +34,7 @@ import java.util.function.ToDoubleFunction;
  *
  * @see ToDoubleFunction
  * @param <T>
- *            the type of the input to the predicate
+ *            the type of the input to the function
  * @param <E>
  *            the type of the potential exception of the function
  */
@@ -72,10 +72,10 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <T, E extends Exception> ToDoubleFunctionWithException<T, E> failing(Supplier<E> exceptionBuilder) {
 		return t -> {
@@ -90,7 +90,7 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	 * @param function
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked exception
@@ -113,7 +113,7 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the unchecked function
@@ -148,7 +148,7 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
@@ -167,7 +167,7 @@ public interface ToDoubleFunctionWithException<T, E extends Exception>
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the input object to the function
+	 *            the type of the input to the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToIntBiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToIntBiFunctionWithException.java
@@ -19,24 +19,24 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToIntBiFunction;
 
 /**
- * Represents a predicate (boolean-valued function) of one argument and may
- * throw an exception.
+ * Represents a function that accepts two arguments and produces an int-valued
+ * result. This is the {@code int}-producing primitive specialization for
+ * {@link BiFunctionWithException}.
  *
- * @author borettim
- * @see Predicate
+ * @see ToIntBiFunction
  * @param <T>
- *            the type of the first input to the predicate
+ *            the type of the first argument to the function
  * @param <U>
- *            the type of the second argument the predicate
+ *            the type of the second argument to the function
  * @param <E>
  *            the type of the potential exception of the function
  */
@@ -45,14 +45,13 @@ public interface ToIntBiFunctionWithException<T, U, E extends Exception>
 		extends PrimitiveReturnExceptionHandlerSupport<ToIntBiFunction<T, U>> {
 
 	/**
-	 * Evaluates this predicate on the given arguments.
+	 * Applies this function to the given arguments.
 	 *
 	 * @param t
-	 *            the first input argument
+	 *            the first function argument
 	 * @param u
-	 *            the first second argument
-	 * @return {@code true} if the input argument matches the predicate, otherwise
-	 *         {@code false}
+	 *            the second function argument
+	 * @return the function result
 	 * @throws E
 	 *             any exception
 	 * @see ToIntBiFunction#applyAsInt(Object, Object)
@@ -72,14 +71,14 @@ public interface ToIntBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the exception
 	 * @return a predicate that always throw exception
@@ -91,48 +90,52 @@ public interface ToIntBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a {@code ToIntBiFunction} that
-	 * convert exception to {@code RuntimeException}.
+	 * Converts a {@code ToIntBiFunctionWithException} to a {@code ToIntBiFunction}
+	 * that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(ToIntBiFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, E extends Exception> ToIntBiFunction<T, U> unchecked(ToIntBiFunctionWithException<T, U, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a {@code ToIntBiFunction} that
-	 * convert exception to {@code RuntimeException} by using the provided mapping
-	 * function.
+	 * Converts a {@code ToIntBiFunctionWithException} to a {@code ToIntBiFunction}
+	 * that wraps exception to {@code RuntimeException} by using the provided
+	 * mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(ToIntBiFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <T, U, E extends Exception> ToIntBiFunction<T, U> unchecked(ToIntBiFunctionWithException<T, U, E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new ToIntBiFunctionWithException<T, U, E>() {
 
 			@Override
@@ -149,38 +152,42 @@ public interface ToIntBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a lifted
-	 * {@code ToIntBiFunction} returning {@code null} in case of exception.
+	 * Converts a {@code ToIntBiFunctionWithException} to a lifted
+	 * {@code ToIntBiFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, E extends Exception> ToIntBiFunction<T, U> lifted(ToIntBiFunctionWithException<T, U, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a lifted
-	 * {@code ToIntBiFunction} returning {@code null} in case of exception.
+	 * Converts a {@code ToIntBiFunctionWithException} to a lifted
+	 * {@code ToIntBiFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, E extends Exception> ToIntBiFunction<T, U> ignored(ToIntBiFunctionWithException<T, U, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToIntBiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToIntBiFunctionWithException.java
@@ -31,6 +31,14 @@ import java.util.function.ToIntBiFunction;
  * Represents a function that accepts two arguments and produces an int-valued
  * result. This is the {@code int}-producing primitive specialization for
  * {@link BiFunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsInt(Object, Object) int applyAsInt(T t, U u) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code ToIntBiFunction<T, U>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code ToIntBiFunction<T, U>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code ToIntBiFunction<T, U>}</li>
+ * </ul>
  *
  * @see ToIntBiFunction
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToIntBiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToIntBiFunctionWithException.java
@@ -81,7 +81,7 @@ public interface ToIntBiFunctionWithException<T, U, E extends Exception>
 	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <T, U, E extends Exception> ToIntBiFunctionWithException<T, U, E> failing(Supplier<E> exceptionBuilder) {
 		return (t, u) -> {

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToIntFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToIntFunctionWithException.java
@@ -31,6 +31,14 @@ import java.util.function.ToIntFunction;
  * Represents a function that produces an int-valued result and may throw
  * exception. This is the {@code int}-producing primitive specialization for
  * {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsInt(Object) int applyAsInt(T value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code ToIntFunction<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code ToIntFunction<T>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code ToIntFunction<T>}</li>
+ * </ul>
  *
  * @see ToIntFunction
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToIntFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToIntFunctionWithException.java
@@ -75,7 +75,7 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 	 *            the type of the input object to the function
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <T, E extends Exception> ToIntFunctionWithException<T, E> failing(Supplier<E> exceptionBuilder) {
 		return t -> {

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToIntFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToIntFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,12 +28,13 @@ import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
 /**
- * Represents a function of one argument and may throw an exception.
+ * Represents a function that produces an int-valued result and may throw
+ * exception. This is the {@code int}-producing primitive specialization for
+ * {@link FunctionWithException}.
  *
- * @author borettim
  * @see ToIntFunction
  * @param <T>
- *            the type of the input to the predicate
+ *            the type of the input to the function
  * @param <E>
  *            the type of the potential exception of the function
  */
@@ -41,17 +43,16 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 		extends PrimitiveReturnExceptionHandlerSupport<ToIntFunction<T>> {
 
 	/**
-	 * Evaluates this function on the given argument.
+	 * Applies this function to the given argument.
 	 *
-	 * @param t
-	 *            the input argument
-	 * @return {@code true} if the input argument matches the predicate, otherwise
-	 *         {@code false}
+	 * @param value
+	 *            the function argument
+	 * @return the function result
 	 * @throws E
 	 *             any exception
 	 * @see ToIntFunction#applyAsInt(Object)
 	 */
-	int applyAsInt(T t) throws E;
+	int applyAsInt(T value) throws E;
 
 	@Override
 	default ToIntFunction<T> uncheckOrIgnore(boolean uncheck) {
@@ -66,7 +67,7 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
@@ -83,8 +84,8 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code ToLongFunctionException} to a {@code ToIntFunction} that
-	 * convert exception to {@code RuntimeException}.
+	 * Converts a {@code ToIntFunctionException} to a {@code ToIntFunction} that
+	 * wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
@@ -95,6 +96,8 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(ToIntFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> ToIntFunction<T> unchecked(ToIntFunctionWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -102,7 +105,7 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ToLongFunctionWithException} to a {@code ToIntFunction}
-	 * that convert exception to {@code RuntimeException} by using the provided
+	 * that wraps exception to {@code RuntimeException} by using the provided
 	 * mapping function.
 	 *
 	 * @param function
@@ -116,16 +119,18 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(ToIntFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <T, E extends Exception> ToIntFunction<T> unchecked(ToIntFunctionWithException<T, E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new ToIntFunctionWithException<T, E>() {
 
 			@Override
-			public int applyAsInt(T t) throws E {
-				return function.applyAsInt(t);
+			public int applyAsInt(T value) throws E {
+				return function.applyAsInt(value);
 			}
 
 			@Override
@@ -138,7 +143,7 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ToLongFunctionWithException} to a lifted
-	 * {@code ToIntFunction} returning {@code null} in case of exception.
+	 * {@code ToIntFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -148,6 +153,8 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> ToIntFunction<T> lifted(ToIntFunctionWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
@@ -155,7 +162,7 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ToLongFunctionWithException} to a lifted
-	 * {@code ToIntFunction} returning {@code null} in case of exception.
+	 * {@code ToIntFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -165,6 +172,8 @@ public interface ToIntFunctionWithException<T, E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> ToIntFunction<T> ignored(ToIntFunctionWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToLongBiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToLongBiFunctionWithException.java
@@ -31,6 +31,14 @@ import java.util.function.ToLongBiFunction;
  * Represents a function that accepts two arguments, may throw exception and
  * produces a long-valued result. This is the {@code long}-producing primitive
  * specialization for {@link BiFunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsLong(Object, Object) long applyAsLong(T t, U u) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code ToLongBiFunction<T, U>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code ToLongBiFunction<T, U>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code ToLongBiFunction<T, U>}</li>
+ * </ul>
  *
  * @see ToLongBiFunction
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToLongBiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToLongBiFunctionWithException.java
@@ -19,24 +19,24 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToLongBiFunction;
 
 /**
- * Represents a predicate (boolean-valued function) of one argument and may
- * throw an exception.
+ * Represents a function that accepts two arguments, may throw exception and
+ * produces a long-valued result. This is the {@code long}-producing primitive
+ * specialization for {@link BiFunctionWithException}.
  *
- * @author borettim
- * @see Predicate
+ * @see ToLongBiFunction
  * @param <T>
- *            the type of the first input to the predicate
+ *            the type of the first argument to the function
  * @param <U>
- *            the type of the second argument the predicate
+ *            the type of the second argument to the function
  * @param <E>
  *            the type of the potential exception of the function
  */
@@ -45,14 +45,13 @@ public interface ToLongBiFunctionWithException<T, U, E extends Exception>
 		extends PrimitiveReturnExceptionHandlerSupport<ToLongBiFunction<T, U>> {
 
 	/**
-	 * Evaluates this predicate on the given arguments.
+	 * Applies this function to the given arguments.
 	 *
 	 * @param t
-	 *            the first input argument
+	 *            the first function argument
 	 * @param u
-	 *            the first second argument
-	 * @return {@code true} if the input argument matches the predicate, otherwise
-	 *         {@code false}
+	 *            the second function argument
+	 * @return the function result
 	 * @throws E
 	 *             any exception
 	 * @see ToLongBiFunction#applyAsLong(Object, Object)
@@ -72,14 +71,14 @@ public interface ToLongBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the exception
 	 * @return a predicate that always throw exception
@@ -91,20 +90,22 @@ public interface ToLongBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a {@code ToLongBiFunction}
-	 * that convert exception to {@code RuntimeException}.
+	 * Converts a {@code ToLongBiFunctionWithException} to a
+	 * {@code ToLongBiFunction} that wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(ToLongBiFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, E extends Exception> ToLongBiFunction<T, U> unchecked(
 			ToLongBiFunctionWithException<T, U, E> function) {
@@ -112,28 +113,30 @@ public interface ToLongBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a {@code ToLongBiFunction}
-	 * that convert exception to {@code RuntimeException} by using the provided
-	 * mapping function.
+	 * Converts a {@code ToLongBiFunctionWithException} to a
+	 * {@code ToLongBiFunction} that wraps exception to {@code RuntimeException} by
+	 * using the provided mapping function.
 	 *
 	 * @param function
 	 *            the be unchecked
 	 * @param exceptionMapper
 	 *            a function to convert the exception to the runtime exception.
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(ToLongBiFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <T, U, E extends Exception> ToLongBiFunction<T, U> unchecked(ToLongBiFunctionWithException<T, U, E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new ToLongBiFunctionWithException<T, U, E>() {
 
 			@Override
@@ -150,38 +153,42 @@ public interface ToLongBiFunctionWithException<T, U, E extends Exception>
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a lifted
-	 * {@code ToLongBiFunction} returning {@code null} in case of exception.
+	 * Converts a {@code ToLongBiFunctionWithException} to a lifted
+	 * {@code ToLongBiFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, E extends Exception> ToLongBiFunction<T, U> lifted(ToLongBiFunctionWithException<T, U, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
 	}
 
 	/**
-	 * Converts a {@code BiPredicateWithException} to a lifted
-	 * {@code ToLongBiFunction} returning {@code null} in case of exception.
+	 * Converts a {@code ToLongBiFunctionWithException} to a lifted
+	 * {@code ToLongBiFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
 	 * @param <T>
-	 *            the type of the first input object to the function
+	 *            the type of the first argument to the function
 	 * @param <U>
-	 *            the type of the second input object to the function
+	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, U, E extends Exception> ToLongBiFunction<T, U> ignored(ToLongBiFunctionWithException<T, U, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToLongBiFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToLongBiFunctionWithException.java
@@ -81,7 +81,7 @@ public interface ToLongBiFunctionWithException<T, U, E extends Exception>
 	 *            the type of the second argument to the function
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <T, U, E extends Exception> ToLongBiFunctionWithException<T, U, E> failing(Supplier<E> exceptionBuilder) {
 		return (t, u) -> {

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToLongFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToLongFunctionWithException.java
@@ -67,7 +67,7 @@ public interface ToLongFunctionWithException<T, E extends Exception>
 	}
 
 	/**
-	 * Returns a predicate that always throw exception.
+	 * Returns a function that always throw exception.
 	 *
 	 * @param exceptionBuilder
 	 *            the supplier to create the exception

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToLongFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToLongFunctionWithException.java
@@ -75,7 +75,7 @@ public interface ToLongFunctionWithException<T, E extends Exception>
 	 *            the type of the input object to the function
 	 * @param <E>
 	 *            the type of the exception
-	 * @return a predicate that always throw exception
+	 * @return a function that always throw exception
 	 */
 	static <T, E extends Exception> ToLongFunctionWithException<T, E> failing(Supplier<E> exceptionBuilder) {
 		return value -> {

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToLongFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToLongFunctionWithException.java
@@ -19,6 +19,7 @@
  */
 package ch.powerunit.extensions.exceptions;
 
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
 import static ch.powerunit.extensions.exceptions.Constants.FUNCTION_CANT_BE_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -27,11 +28,10 @@ import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
 
 /**
- * Represents a function that produces a long-valued result and may thrown
+ * Represents a function that produces a long-valued result and may throw
  * exception. This is the {@code long}-producing primitive specialization for
  * {@link FunctionWithException}.
  *
- * @author borettim
  * @see ToLongFunction
  * @param <T>
  *            the type of the input to the function
@@ -85,7 +85,7 @@ public interface ToLongFunctionWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ToLongFunctionException} to a {@code ToLongFunction} that
-	 * convert exception to {@code RuntimeException}.
+	 * wraps exception to {@code RuntimeException}.
 	 *
 	 * @param function
 	 *            to be unchecked
@@ -96,6 +96,8 @@ public interface ToLongFunctionWithException<T, E extends Exception>
 	 * @return the unchecked exception
 	 * @see #uncheck()
 	 * @see #unchecked(ToLongFunctionWithException, Function)
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> ToLongFunction<T> unchecked(ToLongFunctionWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).uncheck();
@@ -103,7 +105,7 @@ public interface ToLongFunctionWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ToLongFunctionWithException} to a {@code ToLongFunction}
-	 * that convert exception to {@code RuntimeException} by using the provided
+	 * that wraps exception to {@code RuntimeException} by using the provided
 	 * mapping function.
 	 *
 	 * @param function
@@ -114,14 +116,16 @@ public interface ToLongFunctionWithException<T, E extends Exception>
 	 *            the type of the input object to the function
 	 * @param <E>
 	 *            the type of the potential exception
-	 * @return the unchecked exception
+	 * @return the unchecked function
 	 * @see #uncheck()
 	 * @see #unchecked(ToLongFunctionWithException)
+	 * @throws NullPointerException
+	 *             if function or exceptionMapper is null
 	 */
 	static <T, E extends Exception> ToLongFunction<T> unchecked(ToLongFunctionWithException<T, E> function,
 			Function<Exception, RuntimeException> exceptionMapper) {
 		requireNonNull(function, FUNCTION_CANT_BE_NULL);
-		requireNonNull(exceptionMapper, "exceptionMapper can't be null");
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
 		return new ToLongFunctionWithException<T, E>() {
 
 			@Override
@@ -139,7 +143,7 @@ public interface ToLongFunctionWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ToLongFunctionWithException} to a lifted
-	 * {@code ToLongFunction} returning {@code null} in case of exception.
+	 * {@code ToLongFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -149,6 +153,8 @@ public interface ToLongFunctionWithException<T, E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> ToLongFunction<T> lifted(ToLongFunctionWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).lift();
@@ -156,7 +162,7 @@ public interface ToLongFunctionWithException<T, E extends Exception>
 
 	/**
 	 * Converts a {@code ToLongFunctionWithException} to a lifted
-	 * {@code ToLongFunction} returning {@code null} in case of exception.
+	 * {@code ToLongFunction} returning {@code 0} in case of exception.
 	 *
 	 * @param function
 	 *            to be lifted
@@ -166,6 +172,8 @@ public interface ToLongFunctionWithException<T, E extends Exception>
 	 *            the type of the potential exception
 	 * @return the lifted function
 	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if function is null
 	 */
 	static <T, E extends Exception> ToLongFunction<T> ignored(ToLongFunctionWithException<T, E> function) {
 		return requireNonNull(function, FUNCTION_CANT_BE_NULL).ignore();

--- a/src/main/java/ch/powerunit/extensions/exceptions/ToLongFunctionWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/ToLongFunctionWithException.java
@@ -31,6 +31,14 @@ import java.util.function.ToLongFunction;
  * Represents a function that produces a long-valued result and may throw
  * exception. This is the {@code long}-producing primitive specialization for
  * {@link FunctionWithException}.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #applyAsLong(Object) long applyAsLong(T value) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code ToLongFunction<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code ToLongFunction<T>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code ToLongFunction<T>}</li>
+ * </ul>
  *
  * @see ToLongFunction
  * @param <T>

--- a/src/main/java/ch/powerunit/extensions/exceptions/UnaryOperatorWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/UnaryOperatorWithException.java
@@ -36,6 +36,14 @@ import java.util.function.UnaryOperator;
  * <p>
  * As this interface must return the same type of the input, a lifted version
  * which returns {@code Optional} is not possible.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #apply(Object) T apply(T t) throws E}</b>&nbsp;-&nbsp;The
+ * functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code UnaryOperator<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code Function<T,Optional<T>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code UnaryOperator<T>}</li>
+ * </ul>
  *
  * @see FunctionWithException
  * @see UnaryOperator

--- a/src/main/java/ch/powerunit/extensions/exceptions/WrappedException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/WrappedException.java
@@ -22,8 +22,6 @@ package ch.powerunit.extensions.exceptions;
 /**
  * RuntimeException to wrap the Exception.
  *
- * @author borettim
- *
  */
 public final class WrappedException extends RuntimeException {
 

--- a/src/test/java/ch/powerunit/extensions/exceptions/BinaryOperatorWithExceptionTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/BinaryOperatorWithExceptionTest.java
@@ -62,4 +62,16 @@ public class BinaryOperatorWithExceptionTest implements TestSuite {
 		}).apply("x", "x")).isNull();
 	}
 
+	@Test
+	public void testLiftedNoException() {
+		assertThat(BinaryOperatorWithException.lifted((x, y) -> "" + x + y).apply("2", "1")).is(optionalIs("21"));
+	}
+
+	@Test
+	public void testLiftedException() {
+		assertThat(BinaryOperatorWithException.lifted((x, y) -> {
+			throw new Exception();
+		}).apply("x", "x")).is(optionalIsNotPresent());
+	}
+
 }

--- a/src/test/java/ch/powerunit/extensions/exceptions/UnaryOperatorWithExceptionTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/UnaryOperatorWithExceptionTest.java
@@ -80,4 +80,16 @@ public class UnaryOperatorWithExceptionTest implements TestSuite {
 			throw new Exception();
 		}).apply("x")).isNull();
 	}
+
+	@Test
+	public void testLiftedNoException() {
+		assertThat(UnaryOperatorWithException.lifted(x -> x + "1").apply("2")).is(optionalIs("21"));
+	}
+
+	@Test
+	public void testLiftedException() {
+		assertThat(UnaryOperatorWithException.lifted(y -> {
+			throw new Exception();
+		}).apply("x")).is(optionalIsNotPresent());
+	}
 }

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
@@ -39,8 +39,6 @@ public class BiConsumerSamplesTest implements TestSuite {
 	@Test
 	public void sample1() {
 		
-		fail("test for link with code");
-
 		Handler<String> handler = new Handler<>();
 
 		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
@@ -57,9 +57,8 @@ public class BiConsumerSamplesTest implements TestSuite {
 	@Test
 	public void sample2() {
 
-		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
-			throw new IOException("test");
-		};
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = BiConsumerWithException
+				.failing(IOException::new);
 
 		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
 				.unchecked(consumerThrowingException);
@@ -91,9 +90,8 @@ public class BiConsumerSamplesTest implements TestSuite {
 	@Test
 	public void sample4() {
 
-		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
-			throw new IOException("test");
-		};
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = BiConsumerWithException
+				.failing(IOException::new);
 
 		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
 				.unchecked(consumerThrowingException, IllegalArgumentException::new);
@@ -125,9 +123,8 @@ public class BiConsumerSamplesTest implements TestSuite {
 	@Test
 	public void sample6() {
 
-		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
-			throw new IOException("test");
-		};
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = BiConsumerWithException
+				.failing(IOException::new);
 
 		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
 				.lifted(consumerThrowingException);
@@ -157,9 +154,8 @@ public class BiConsumerSamplesTest implements TestSuite {
 	@Test
 	public void sample8() {
 
-		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
-			throw new IOException("test");
-		};
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = BiConsumerWithException
+				.failing(IOException::new);
 
 		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
 				.ignored(consumerThrowingException);

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
@@ -1,0 +1,105 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.function.BiConsumer;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.BiConsumerWithException;
+import ch.powerunit.extensions.exceptions.WrappedException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class BiConsumerSamplesTest implements TestSuite {
+
+	private class Handler<T> {
+		public T object;
+	}
+
+	@Test
+	public void sample1() {
+
+		Handler<String> handler = new Handler<>();
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
+				.unchecked(consumerThrowingException);
+
+		Collections.singletonMap("x", "y").forEach(consumerThrowingRuntimeException);
+
+		assertThat(handler.object).is("yxy");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
+			throw new IOException("test");
+		};
+
+		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
+				.unchecked(consumerThrowingException);
+
+		assertWhen((x) -> {
+			Collections.singletonMap("x", "y").forEach(consumerThrowingRuntimeException);
+		}).throwException(instanceOf(WrappedException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		Handler<String> handler = new Handler<>();
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
+				.unchecked(consumerThrowingException, IllegalArgumentException::new);
+
+		Collections.singletonMap("x", "y").forEach(consumerThrowingRuntimeException);
+
+		assertThat(handler.object).is("yxy");
+
+	}
+
+	@Test
+	public void sample4() {
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
+			throw new IOException("test");
+		};
+
+		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
+				.unchecked(consumerThrowingException, IllegalArgumentException::new);
+
+		assertWhen((x) -> {
+			Collections.singletonMap("x", "y").forEach(consumerThrowingRuntimeException);
+		}).throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
@@ -38,7 +38,7 @@ public class BiConsumerSamplesTest implements TestSuite {
 
 	@Test
 	public void sample1() {
-		
+
 		Handler<String> handler = new Handler<>();
 
 		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
@@ -38,6 +38,8 @@ public class BiConsumerSamplesTest implements TestSuite {
 
 	@Test
 	public void sample1() {
+		
+		fail("test for link with code");
 
 		Handler<String> handler = new Handler<>();
 

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 import ch.powerunit.Test;
 import ch.powerunit.TestSuite;
 import ch.powerunit.extensions.exceptions.BiConsumerWithException;
+import ch.powerunit.extensions.exceptions.BiFunctionWithException;
 import ch.powerunit.extensions.exceptions.WrappedException;
 
 @SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
@@ -100,6 +101,88 @@ public class BiConsumerSamplesTest implements TestSuite {
 		assertWhen((x) -> {
 			Collections.singletonMap("x", "y").forEach(consumerThrowingRuntimeException);
 		}).throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample5() {
+
+		Handler<String> handler = new Handler<>();
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
+				.lifted(consumerThrowingException);
+
+		Collections.singletonMap("x", "y").forEach(consumerThrowingRuntimeException);
+
+		assertThat(handler.object).is("yxy");
+
+	}
+
+	@Test
+	public void sample6() {
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
+			throw new IOException("test");
+		};
+
+		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
+				.lifted(consumerThrowingException);
+
+		Collections.singletonMap("x", "y").forEach(consumerThrowingRuntimeException);
+
+	}
+
+	@Test
+	public void sample7() {
+
+		Handler<String> handler = new Handler<>();
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
+				.ignored(consumerThrowingException);
+
+		Collections.singletonMap("x", "y").forEach(consumerThrowingRuntimeException);
+
+		assertThat(handler.object).is("yxy");
+
+	}
+
+	@Test
+	public void sample8() {
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
+			throw new IOException("test");
+		};
+
+		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
+				.ignored(consumerThrowingException);
+
+		Collections.singletonMap("x", "y").forEach(consumerThrowingRuntimeException);
+
+	}
+
+	@Test
+	public void sample9() {
+
+		Handler<String> handler = new Handler<>();
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		BiFunctionWithException<String, String, String, IOException> consumerThrowingRuntimeException = BiConsumerWithException
+				.asBiFunction(consumerThrowingException);
+
+		assertThatBiFunction(consumerThrowingRuntimeException.uncheck(), "x", "z").isNull();
+
+		assertThat(handler.object).is("yxz");
 
 	}
 }

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiConsumerSamplesTest.java
@@ -185,4 +185,26 @@ public class BiConsumerSamplesTest implements TestSuite {
 		assertThat(handler.object).is("yxz");
 
 	}
+
+	@Test
+	public void sample10() {
+
+		Handler<String> handler = new Handler<>();
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException1 = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		BiConsumerWithException<String, String, IOException> consumerThrowingException2 = (x, y) -> {
+			handler.object = "z" + y + x + handler.object;
+		};
+
+		BiConsumer<String, String> consumerThrowingRuntimeException = BiConsumerWithException
+				.unchecked(consumerThrowingException1.andThen(consumerThrowingException2));
+
+		Collections.singletonMap("a", "b").forEach(consumerThrowingRuntimeException);
+
+		assertThat(handler.object).is("zbayab");
+
+	}
 }

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiFunctionSamplesTest.java
@@ -21,6 +21,7 @@ package ch.powerunit.extensions.exceptions.samples;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
 import ch.powerunit.Test;
@@ -78,6 +79,20 @@ public class BiFunctionSamplesTest implements TestSuite {
 				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
 
 		assertThatBiFunction(functionThrowingRuntimeException, "x", "y").is("xy");
+
+	}
+
+	@Test
+	public void sample5() {
+
+		BiFunctionWithException<String, String, String, IOException> fonctionThrowingException = String::concat;
+
+		BiFunction<String, String, CompletionStage<String>> functionWithOptionalResult = BiFunctionWithException
+				.staged(fonctionThrowingException);
+
+		CompletionStage<String> result = functionWithOptionalResult.apply("x", "z");
+
+		assertThat(result.whenComplete((r, t) -> assertThat(t).isNull()).toCompletableFuture().join()).is("xz");
 
 	}
 

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiFunctionSamplesTest.java
@@ -69,4 +69,16 @@ public class BiFunctionSamplesTest implements TestSuite {
 
 	}
 
+	@Test
+	public void sample4() {
+
+		BiFunctionWithException<String, String, String, IOException> fonctionThrowingException = String::concat;
+
+		BiFunction<String, String, String> functionThrowingRuntimeException = BiFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThatBiFunction(functionThrowingRuntimeException, "x", "y").is("xy");
+
+	}
+
 }

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiFunctionSamplesTest.java
@@ -46,9 +46,8 @@ public class BiFunctionSamplesTest implements TestSuite {
 	@Test
 	public void sample2() {
 
-		BiFunctionWithException<String, String, String, IOException> fonctionThrowingException = (x, y) -> {
-			throw new IOException();
-		};
+		BiFunctionWithException<String, String, String, IOException> fonctionThrowingException = BiFunctionWithException
+				.failing(IOException::new);
 
 		BiFunction<String, String, String> functionThrowingRuntimeException = BiFunctionWithException
 				.unchecked(fonctionThrowingException, IllegalArgumentException::new);

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiFunctionSamplesTest.java
@@ -1,0 +1,72 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.BiFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class BiFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		BiFunctionWithException<String, String, String, IOException> fonctionThrowingException = String::concat;
+
+		BiFunction<String, String, String> functionThrowingRuntimeException = BiFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThatBiFunction(functionThrowingRuntimeException, "x", "y").is("xy");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		BiFunctionWithException<String, String, String, IOException> fonctionThrowingException = (x, y) -> {
+			throw new IOException();
+		};
+
+		BiFunction<String, String, String> functionThrowingRuntimeException = BiFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.apply(x, x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		BiFunctionWithException<String, String, String, IOException> fonctionThrowingException = String::concat;
+
+		BiFunction<String, String, Optional<String>> functionWithOptionalResult = BiFunctionWithException
+				.lifted(fonctionThrowingException);
+
+		assertThatBiFunction(functionWithOptionalResult, "x", "z").is(optionalIs("xz"));
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BiPredicateSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BiPredicateSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.BiPredicate;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.BiPredicateWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class BiPredicateSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		BiPredicateWithException<String, String, IOException> fonctionThrowingException = (x, y) -> true;
+
+		BiPredicate<String, String> functionThrowingRuntimeException = BiPredicateWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.test("x", "y")).is(true);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		BiPredicateWithException<String, String, IOException> fonctionThrowingException = BiPredicateWithException
+				.failing(IOException::new);
+
+		BiPredicate<String, String> functionThrowingRuntimeException = BiPredicateWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.test(x, x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		BiPredicateWithException<String, String, IOException> fonctionThrowingException = (x, y) -> true;
+
+		BiPredicate<String, String> functionThrowingRuntimeException = BiPredicateWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.test("x", "y")).is(true);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BinaryOperatorSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BinaryOperatorSamplesTest.java
@@ -1,0 +1,84 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.BinaryOperatorWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class BinaryOperatorSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		BinaryOperatorWithException<String, IOException> fonctionThrowingException = String::concat;
+
+		BinaryOperator<String> functionThrowingRuntimeException = BinaryOperatorWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThatBiFunction(functionThrowingRuntimeException, "x", "y").is("xy");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		BinaryOperatorWithException<String, IOException> fonctionThrowingException = BinaryOperatorWithException
+				.failing(IOException::new);
+
+		BinaryOperator<String> functionThrowingRuntimeException = BinaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.apply(x, x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		BinaryOperatorWithException<String, IOException> fonctionThrowingException = String::concat;
+
+		BiFunction<String, String, Optional<String>> functionWithOptionalResult = BinaryOperatorWithException
+				.lifted(fonctionThrowingException);
+
+		assertThatBiFunction(functionWithOptionalResult, "x", "z").is(optionalIs("xz"));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		BinaryOperatorWithException<String, IOException> fonctionThrowingException = String::concat;
+
+		BinaryOperator<String> functionThrowingRuntimeException = BinaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThatBiFunction(functionThrowingRuntimeException, "x", "y").is("xy");
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/BooleanSupplierSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/BooleanSupplierSamplesTest.java
@@ -1,0 +1,83 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.BooleanSupplier;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.BooleanSupplierWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class BooleanSupplierSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		BooleanSupplierWithException<IOException> supplierThrowingException = () -> true;
+
+		BooleanSupplier supplierThrowingRuntimeException = BooleanSupplierWithException
+				.unchecked(supplierThrowingException);
+
+		assertThat(supplierThrowingRuntimeException.getAsBoolean()).is(true);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		BooleanSupplierWithException<IOException> supplierThrowingException = BooleanSupplierWithException
+				.failing(IOException::new);
+
+		BooleanSupplier supplierThrowingRuntimeException = BooleanSupplierWithException
+				.unchecked(supplierThrowingException);
+
+		assertWhen(x -> supplierThrowingRuntimeException.getAsBoolean())
+				.throwException(instanceOf(RuntimeException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		BooleanSupplierWithException<IOException> supplierThrowingException = () -> true;
+
+		BooleanSupplier supplierThrowingRuntimeException = BooleanSupplierWithException
+				.unchecked(supplierThrowingException, IllegalArgumentException::new);
+
+		assertThat(supplierThrowingRuntimeException.getAsBoolean()).is(true);
+
+	}
+
+	@Test
+	public void sample4() {
+
+		BooleanSupplierWithException<IOException> supplierThrowingException = BooleanSupplierWithException
+				.failing(IOException::new);
+
+		BooleanSupplier supplierThrowingRuntimeException = BooleanSupplierWithException
+				.unchecked(supplierThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> supplierThrowingRuntimeException.getAsBoolean())
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ConsumerSamplesTest.java
@@ -55,9 +55,8 @@ public class ConsumerSamplesTest implements TestSuite {
 	@Test
 	public void sample2() {
 
-		ConsumerWithException<String, IOException> consumerThrowingException = x -> {
-			throw new IOException("test");
-		};
+		ConsumerWithException<String, IOException> consumerThrowingException = ConsumerWithException
+				.failing(IOException::new);
 
 		Consumer<String> consumerThrowingRuntimeException = ConsumerWithException.unchecked(consumerThrowingException);
 
@@ -88,9 +87,8 @@ public class ConsumerSamplesTest implements TestSuite {
 	@Test
 	public void sample4() {
 
-		ConsumerWithException<String, IOException> consumerThrowingException = x -> {
-			throw new IOException("test");
-		};
+		ConsumerWithException<String, IOException> consumerThrowingException = ConsumerWithException
+				.failing(IOException::new);
 
 		Consumer<String> consumerThrowingRuntimeException = ConsumerWithException.unchecked(consumerThrowingException,
 				IllegalArgumentException::new);

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ConsumerSamplesTest.java
@@ -100,4 +100,26 @@ public class ConsumerSamplesTest implements TestSuite {
 		}).throwException(instanceOf(IllegalArgumentException.class));
 
 	}
+
+	@Test
+	public void sample5() {
+
+		Handler<String> handler = new Handler<>();
+
+		ConsumerWithException<String, IOException> consumerThrowingException1 = x -> {
+			handler.object = "y" + x;
+		};
+
+		ConsumerWithException<String, IOException> consumerThrowingException2 = x -> {
+			handler.object = handler.object + "y" + x;
+		};
+
+		Consumer<String> consumerThrowingRuntimeException = ConsumerWithException
+				.unchecked(consumerThrowingException1.andThen(consumerThrowingException2));
+
+		Stream.of("z").forEach(consumerThrowingRuntimeException);
+
+		assertThat(handler.object).is("yzyz");
+
+	}
 }

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ConsumerSamplesTest.java
@@ -1,0 +1,103 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.ConsumerWithException;
+import ch.powerunit.extensions.exceptions.WrappedException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class ConsumerSamplesTest implements TestSuite {
+
+	private class Handler<T> {
+		public T object;
+	}
+
+	@Test
+	public void sample1() {
+
+		Handler<String> handler = new Handler<>();
+
+		ConsumerWithException<String, IOException> consumerThrowingException = x -> {
+			handler.object = "y" + x;
+		};
+
+		Consumer<String> consumerThrowingRuntimeException = ConsumerWithException.unchecked(consumerThrowingException);
+
+		Stream.of("z").forEach(consumerThrowingRuntimeException);
+
+		assertThat(handler.object).is("yz");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		ConsumerWithException<String, IOException> consumerThrowingException = x -> {
+			throw new IOException("test");
+		};
+
+		Consumer<String> consumerThrowingRuntimeException = ConsumerWithException.unchecked(consumerThrowingException);
+
+		assertWhen((x) -> {
+			Stream.of("z").forEach(consumerThrowingRuntimeException);
+		}).throwException(instanceOf(WrappedException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		Handler<String> handler = new Handler<>();
+
+		ConsumerWithException<String, IOException> consumerThrowingException = x -> {
+			handler.object = "y" + x;
+		};
+
+		Consumer<String> consumerThrowingRuntimeException = ConsumerWithException.unchecked(consumerThrowingException,
+				IllegalArgumentException::new);
+
+		Stream.of("z").forEach(consumerThrowingRuntimeException);
+
+		assertThat(handler.object).is("yz");
+
+	}
+
+	@Test
+	public void sample4() {
+
+		ConsumerWithException<String, IOException> consumerThrowingException = x -> {
+			throw new IOException("test");
+		};
+
+		Consumer<String> consumerThrowingRuntimeException = ConsumerWithException.unchecked(consumerThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen((x) -> {
+			Stream.of("z").forEach(consumerThrowingRuntimeException);
+		}).throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleBinaryOperatorSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleBinaryOperatorSamplesTest.java
@@ -1,0 +1,82 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.DoubleBinaryOperator;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.DoubleBinaryOperatorWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class DoubleBinaryOperatorSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		DoubleBinaryOperatorWithException<IOException> fonctionThrowingException = (x, y) -> x + y;
+
+		DoubleBinaryOperator functionThrowingRuntimeException = DoubleBinaryOperatorWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble(1, 2)).is(3d);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		DoubleBinaryOperatorWithException<IOException> fonctionThrowingException = DoubleBinaryOperatorWithException
+				.failing(IOException::new);
+
+		DoubleBinaryOperator functionThrowingRuntimeException = DoubleBinaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsDouble(1, 2))
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		DoubleBinaryOperatorWithException<IOException> fonctionThrowingException = (x, y) -> x + y;
+
+		DoubleBinaryOperator functionWithOptionalResult = DoubleBinaryOperatorWithException
+				.lifted(fonctionThrowingException);
+
+		assertThat(functionWithOptionalResult.applyAsDouble(1, 2)).is(3d);
+
+	}
+
+	@Test
+	public void sample4() {
+
+		DoubleBinaryOperatorWithException<IOException> fonctionThrowingException = (x, y) -> x + y;
+
+		DoubleBinaryOperator functionThrowingRuntimeException = DoubleBinaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble(1, 2)).is(3d);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleConsumerSamplesTest.java
@@ -1,0 +1,124 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.DoubleConsumer;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.DoubleConsumerWithException;
+import ch.powerunit.extensions.exceptions.WrappedException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class DoubleConsumerSamplesTest implements TestSuite {
+
+	private class Handler<T> {
+		public T object;
+	}
+
+	@Test
+	public void sample1() {
+
+		Handler<String> handler = new Handler<>();
+
+		DoubleConsumerWithException<IOException> consumerThrowingException = x -> {
+			handler.object = "y" + x;
+		};
+
+		DoubleConsumer consumerThrowingRuntimeException = DoubleConsumerWithException
+				.unchecked(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept(12);
+
+		assertThat(handler.object).is("y12.0");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		DoubleConsumerWithException<IOException> consumerThrowingException = DoubleConsumerWithException
+				.failing(IOException::new);
+
+		DoubleConsumer consumerThrowingRuntimeException = DoubleConsumerWithException
+				.unchecked(consumerThrowingException);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept(12);
+		}).throwException(instanceOf(WrappedException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		Handler<String> handler = new Handler<>();
+
+		DoubleConsumerWithException<IOException> consumerThrowingException = x -> {
+			handler.object = "y" + x;
+		};
+
+		DoubleConsumer consumerThrowingRuntimeException = DoubleConsumerWithException
+				.unchecked(consumerThrowingException, IllegalArgumentException::new);
+
+		consumerThrowingRuntimeException.accept(12);
+
+		assertThat(handler.object).is("y12.0");
+
+	}
+
+	@Test
+	public void sample4() {
+
+		DoubleConsumerWithException<IOException> consumerThrowingException = DoubleConsumerWithException
+				.failing(IOException::new);
+
+		DoubleConsumer consumerThrowingRuntimeException = DoubleConsumerWithException
+				.unchecked(consumerThrowingException, IllegalArgumentException::new);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept(12);
+		}).throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample5() {
+
+		Handler<String> handler = new Handler<>();
+
+		DoubleConsumerWithException<IOException> consumerThrowingException1 = x -> {
+			handler.object = "y" + x;
+		};
+
+		DoubleConsumerWithException<IOException> consumerThrowingException2 = x -> {
+			handler.object = handler.object + "y" + x;
+		};
+
+		DoubleConsumer consumerThrowingRuntimeException = DoubleConsumerWithException
+				.unchecked(consumerThrowingException1.andThen(consumerThrowingException2));
+
+		consumerThrowingRuntimeException.accept(23);
+
+		assertThat(handler.object).is("y23.0y23.0");
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleFunctionSamplesTest.java
@@ -1,0 +1,83 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.DoubleFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.DoubleFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class DoubleFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		DoubleFunctionWithException<String, IOException> fonctionThrowingException = x -> "x";
+
+		DoubleFunction<String> functionThrowingRuntimeException = DoubleFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.apply(2)).is("x");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		DoubleFunctionWithException<String, IOException> fonctionThrowingException = DoubleFunctionWithException
+				.failing(IOException::new);
+
+		DoubleFunction<String> functionThrowingRuntimeException = DoubleFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.apply(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		DoubleFunctionWithException<String, IOException> fonctionThrowingException = x -> "x";
+
+		DoubleFunction<Optional<String>> functionWithOptionalResult = DoubleFunctionWithException
+				.lifted(fonctionThrowingException);
+
+		assertThat(functionWithOptionalResult.apply(1)).is(optionalIs("x"));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		DoubleFunctionWithException<String, IOException> fonctionThrowingException = x -> "x";
+
+		DoubleFunction<String> functionThrowingRuntimeException = DoubleFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.apply(2)).is("x");
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/DoublePredicateSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/DoublePredicateSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.DoublePredicate;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.DoublePredicateWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class DoublePredicateSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		DoublePredicateWithException<IOException> fonctionThrowingException = x -> true;
+
+		DoublePredicate functionThrowingRuntimeException = DoublePredicateWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.test(2)).is(true);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		DoublePredicateWithException<IOException> fonctionThrowingException = DoublePredicateWithException
+				.failing(IOException::new);
+
+		DoublePredicate functionThrowingRuntimeException = DoublePredicateWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.test(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		DoublePredicateWithException<IOException> fonctionThrowingException = x -> true;
+
+		DoublePredicate functionThrowingRuntimeException = DoublePredicateWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.test(2)).is(true);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleSupplierSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleSupplierSamplesTest.java
@@ -1,0 +1,83 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.DoubleSupplier;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.DoubleSupplierWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class DoubleSupplierSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		DoubleSupplierWithException<IOException> supplierThrowingException = () -> 12;
+
+		DoubleSupplier supplierThrowingRuntimeException = DoubleSupplierWithException
+				.unchecked(supplierThrowingException);
+
+		assertThat(supplierThrowingRuntimeException.getAsDouble()).is(12d);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		DoubleSupplierWithException<IOException> supplierThrowingException = DoubleSupplierWithException
+				.failing(IOException::new);
+
+		DoubleSupplier supplierThrowingRuntimeException = DoubleSupplierWithException
+				.unchecked(supplierThrowingException);
+
+		assertWhen(x -> supplierThrowingRuntimeException.getAsDouble())
+				.throwException(instanceOf(RuntimeException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		DoubleSupplierWithException<IOException> supplierThrowingException = () -> 12;
+
+		DoubleSupplier supplierThrowingRuntimeException = DoubleSupplierWithException
+				.unchecked(supplierThrowingException, IllegalArgumentException::new);
+
+		assertThat(supplierThrowingRuntimeException.getAsDouble()).is(12d);
+
+	}
+
+	@Test
+	public void sample4() {
+
+		DoubleSupplierWithException<IOException> supplierThrowingException = DoubleSupplierWithException
+				.failing(IOException::new);
+
+		DoubleSupplier supplierThrowingRuntimeException = DoubleSupplierWithException
+				.unchecked(supplierThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> supplierThrowingRuntimeException.getAsDouble())
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleToIntFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleToIntFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.DoubleToIntFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.DoubleToIntFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class DoubleToIntFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		DoubleToIntFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		DoubleToIntFunction functionThrowingRuntimeException = DoubleToIntFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt(2)).is(1);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		DoubleToIntFunctionWithException<IOException> fonctionThrowingException = DoubleToIntFunctionWithException
+				.failing(IOException::new);
+
+		DoubleToIntFunction functionThrowingRuntimeException = DoubleToIntFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsInt(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		DoubleToIntFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		DoubleToIntFunction functionThrowingRuntimeException = DoubleToIntFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt(2)).is(1);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleToLongFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleToLongFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.DoubleToLongFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.DoubleToLongFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class DoubleToLongFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		DoubleToLongFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		DoubleToLongFunction functionThrowingRuntimeException = DoubleToLongFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong(2)).is(1L);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		DoubleToLongFunctionWithException<IOException> fonctionThrowingException = DoubleToLongFunctionWithException
+				.failing(IOException::new);
+
+		DoubleToLongFunction functionThrowingRuntimeException = DoubleToLongFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsLong(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		DoubleToLongFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		DoubleToLongFunction functionThrowingRuntimeException = DoubleToLongFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong(2)).is(1L);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleUnaryOperatorSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/DoubleUnaryOperatorSamplesTest.java
@@ -1,0 +1,82 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.DoubleUnaryOperator;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.DoubleUnaryOperatorWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class DoubleUnaryOperatorSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		DoubleUnaryOperatorWithException<IOException> fonctionThrowingException = x -> x + 1;
+
+		DoubleUnaryOperator functionThrowingRuntimeException = DoubleUnaryOperatorWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble(1)).is(2d);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		DoubleUnaryOperatorWithException<IOException> fonctionThrowingException = DoubleUnaryOperatorWithException
+				.failing(IOException::new);
+
+		DoubleUnaryOperator functionThrowingRuntimeException = DoubleUnaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsDouble(x), 1)
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		DoubleUnaryOperatorWithException<IOException> fonctionThrowingException = x -> x + 1;
+
+		DoubleUnaryOperator functionWithOptionalResult = DoubleUnaryOperatorWithException
+				.lifted(fonctionThrowingException);
+
+		assertThat(functionWithOptionalResult.applyAsDouble(1)).is(2d);
+
+	}
+
+	@Test
+	public void sample4() {
+
+		DoubleUnaryOperatorWithException<IOException> fonctionThrowingException = x -> x + 1;
+
+		DoubleUnaryOperator functionThrowingRuntimeException = DoubleUnaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble(1)).is(2d);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/FunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/FunctionSamplesTest.java
@@ -45,9 +45,8 @@ public class FunctionSamplesTest implements TestSuite {
 	@Test
 	public void sample2() {
 
-		FunctionWithException<String, String, IOException> fonctionThrowingException = x -> {
-			throw new IOException();
-		};
+		FunctionWithException<String, String, IOException> fonctionThrowingException = FunctionWithException
+				.failing(IOException::new);
 
 		Function<String, String> functionThrowingRuntimeException = FunctionWithException
 				.unchecked(fonctionThrowingException, IllegalArgumentException::new);

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/FunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/FunctionSamplesTest.java
@@ -69,4 +69,16 @@ public class FunctionSamplesTest implements TestSuite {
 
 	}
 
+	@Test
+	public void sample4() {
+
+		FunctionWithException<String, String, IOException> fonctionThrowingException = x -> x;
+
+		Function<String, String> functionThrowingRuntimeException = FunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThatFunction(functionThrowingRuntimeException, "x").is("x");
+
+	}
+
 }

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/FunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/FunctionSamplesTest.java
@@ -23,12 +23,14 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Function;
 
+import ch.powerunit.Test;
 import ch.powerunit.TestSuite;
 import ch.powerunit.extensions.exceptions.FunctionWithException;
 
 @SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
 public class FunctionSamplesTest implements TestSuite {
 
+	@Test
 	public void sample1() {
 
 		FunctionWithException<String, String, IOException> fonctionThrowingException = x -> x;
@@ -40,9 +42,12 @@ public class FunctionSamplesTest implements TestSuite {
 
 	}
 
+	@Test
 	public void sample2() {
 
-		FunctionWithException<String, String, IOException> fonctionThrowingException = x -> x;
+		FunctionWithException<String, String, IOException> fonctionThrowingException = x -> {
+			throw new IOException();
+		};
 
 		Function<String, String> functionThrowingRuntimeException = FunctionWithException
 				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
@@ -52,6 +57,7 @@ public class FunctionSamplesTest implements TestSuite {
 
 	}
 
+	@Test
 	public void sample3() {
 
 		FunctionWithException<String, String, IOException> fonctionThrowingException = x -> x;

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/IntBinaryOperatorSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/IntBinaryOperatorSamplesTest.java
@@ -1,0 +1,81 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.IntBinaryOperator;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.IntBinaryOperatorWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class IntBinaryOperatorSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		IntBinaryOperatorWithException<IOException> fonctionThrowingException = (x, y) -> x + y;
+
+		IntBinaryOperator functionThrowingRuntimeException = IntBinaryOperatorWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt(1, 2)).is(3);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		IntBinaryOperatorWithException<IOException> fonctionThrowingException = IntBinaryOperatorWithException
+				.failing(IOException::new);
+
+		IntBinaryOperator functionThrowingRuntimeException = IntBinaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsInt(1, 2))
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		IntBinaryOperatorWithException<IOException> fonctionThrowingException = (x, y) -> x + y;
+
+		IntBinaryOperator functionWithOptionalResult = IntBinaryOperatorWithException.lifted(fonctionThrowingException);
+
+		assertThat(functionWithOptionalResult.applyAsInt(1, 2)).is(3);
+
+	}
+
+	@Test
+	public void sample4() {
+
+		IntBinaryOperatorWithException<IOException> fonctionThrowingException = (x, y) -> x + y;
+
+		IntBinaryOperator functionThrowingRuntimeException = IntBinaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt(1, 2)).is(3);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/IntConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/IntConsumerSamplesTest.java
@@ -1,0 +1,122 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.IntConsumer;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.IntConsumerWithException;
+import ch.powerunit.extensions.exceptions.WrappedException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class IntConsumerSamplesTest implements TestSuite {
+
+	private class Handler<T> {
+		public T object;
+	}
+
+	@Test
+	public void sample1() {
+
+		Handler<String> handler = new Handler<>();
+
+		IntConsumerWithException<IOException> consumerThrowingException = x -> {
+			handler.object = "y" + x;
+		};
+
+		IntConsumer consumerThrowingRuntimeException = IntConsumerWithException.unchecked(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept(12);
+
+		assertThat(handler.object).is("y12");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		IntConsumerWithException<IOException> consumerThrowingException = IntConsumerWithException
+				.failing(IOException::new);
+
+		IntConsumer consumerThrowingRuntimeException = IntConsumerWithException.unchecked(consumerThrowingException);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept(12);
+		}).throwException(instanceOf(WrappedException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		Handler<String> handler = new Handler<>();
+
+		IntConsumerWithException<IOException> consumerThrowingException = x -> {
+			handler.object = "y" + x;
+		};
+
+		IntConsumer consumerThrowingRuntimeException = IntConsumerWithException.unchecked(consumerThrowingException,
+				IllegalArgumentException::new);
+
+		consumerThrowingRuntimeException.accept(12);
+
+		assertThat(handler.object).is("y12");
+
+	}
+
+	@Test
+	public void sample4() {
+
+		IntConsumerWithException<IOException> consumerThrowingException = IntConsumerWithException
+				.failing(IOException::new);
+
+		IntConsumer consumerThrowingRuntimeException = IntConsumerWithException.unchecked(consumerThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept(12);
+		}).throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample5() {
+
+		Handler<String> handler = new Handler<>();
+
+		IntConsumerWithException<IOException> consumerThrowingException1 = x -> {
+			handler.object = "y" + x;
+		};
+
+		IntConsumerWithException<IOException> consumerThrowingException2 = x -> {
+			handler.object = handler.object + "y" + x;
+		};
+
+		IntConsumer consumerThrowingRuntimeException = IntConsumerWithException
+				.unchecked(consumerThrowingException1.andThen(consumerThrowingException2));
+
+		consumerThrowingRuntimeException.accept(23);
+
+		assertThat(handler.object).is("y23y23");
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/IntFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/IntFunctionSamplesTest.java
@@ -1,0 +1,83 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.IntFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.IntFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class IntFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		IntFunctionWithException<String, IOException> fonctionThrowingException = x -> "x";
+
+		IntFunction<String> functionThrowingRuntimeException = IntFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.apply(2)).is("x");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		IntFunctionWithException<String, IOException> fonctionThrowingException = IntFunctionWithException
+				.failing(IOException::new);
+
+		IntFunction<String> functionThrowingRuntimeException = IntFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.apply(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		IntFunctionWithException<String, IOException> fonctionThrowingException = x -> "x";
+
+		IntFunction<Optional<String>> functionWithOptionalResult = IntFunctionWithException
+				.lifted(fonctionThrowingException);
+
+		assertThat(functionWithOptionalResult.apply(1)).is(optionalIs("x"));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		IntFunctionWithException<String, IOException> fonctionThrowingException = x -> "x";
+
+		IntFunction<String> functionThrowingRuntimeException = IntFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.apply(2)).is("x");
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/IntPredicateSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/IntPredicateSamplesTest.java
@@ -1,0 +1,69 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.IntPredicate;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.IntPredicateWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class IntPredicateSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		IntPredicateWithException<IOException> fonctionThrowingException = x -> true;
+
+		IntPredicate functionThrowingRuntimeException = IntPredicateWithException.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.test(2)).is(true);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		IntPredicateWithException<IOException> fonctionThrowingException = IntPredicateWithException
+				.failing(IOException::new);
+
+		IntPredicate functionThrowingRuntimeException = IntPredicateWithException.unchecked(fonctionThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.test(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		IntPredicateWithException<IOException> fonctionThrowingException = x -> true;
+
+		IntPredicate functionThrowingRuntimeException = IntPredicateWithException.unchecked(fonctionThrowingException,
+				IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.test(2)).is(true);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/IntSupplierSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/IntSupplierSamplesTest.java
@@ -1,0 +1,80 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.IntSupplier;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.IntSupplierWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class IntSupplierSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		IntSupplierWithException<IOException> supplierThrowingException = () -> 12;
+
+		IntSupplier supplierThrowingRuntimeException = IntSupplierWithException.unchecked(supplierThrowingException);
+
+		assertThat(supplierThrowingRuntimeException.getAsInt()).is(12);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		IntSupplierWithException<IOException> supplierThrowingException = IntSupplierWithException
+				.failing(IOException::new);
+
+		IntSupplier supplierThrowingRuntimeException = IntSupplierWithException.unchecked(supplierThrowingException);
+
+		assertWhen(x -> supplierThrowingRuntimeException.getAsInt()).throwException(instanceOf(RuntimeException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		IntSupplierWithException<IOException> supplierThrowingException = () -> 12;
+
+		IntSupplier supplierThrowingRuntimeException = IntSupplierWithException.unchecked(supplierThrowingException,
+				IllegalArgumentException::new);
+
+		assertThat(supplierThrowingRuntimeException.getAsInt()).is(12);
+
+	}
+
+	@Test
+	public void sample4() {
+
+		IntSupplierWithException<IOException> supplierThrowingException = IntSupplierWithException
+				.failing(IOException::new);
+
+		IntSupplier supplierThrowingRuntimeException = IntSupplierWithException.unchecked(supplierThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen(x -> supplierThrowingRuntimeException.getAsInt())
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/IntToDoubleFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/IntToDoubleFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.IntToDoubleFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.IntToDoubleFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class IntToDoubleFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		IntToDoubleFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		IntToDoubleFunction functionThrowingRuntimeException = IntToDoubleFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble(2)).is(1d);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		IntToDoubleFunctionWithException<IOException> fonctionThrowingException = IntToDoubleFunctionWithException
+				.failing(IOException::new);
+
+		IntToDoubleFunction functionThrowingRuntimeException = IntToDoubleFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsDouble(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		IntToDoubleFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		IntToDoubleFunction functionThrowingRuntimeException = IntToDoubleFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble(2)).is(1d);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/IntToLongFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/IntToLongFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.IntToLongFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.IntToLongFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class IntToLongFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		IntToLongFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		IntToLongFunction functionThrowingRuntimeException = IntToLongFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong(2)).is(1L);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		IntToLongFunctionWithException<IOException> fonctionThrowingException = IntToLongFunctionWithException
+				.failing(IOException::new);
+
+		IntToLongFunction functionThrowingRuntimeException = IntToLongFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsLong(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		IntToLongFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		IntToLongFunction functionThrowingRuntimeException = IntToLongFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong(2)).is(1L);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/IntUnaryOperatorSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/IntUnaryOperatorSamplesTest.java
@@ -1,0 +1,81 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.IntUnaryOperator;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.IntUnaryOperatorWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class IntUnaryOperatorSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		IntUnaryOperatorWithException<IOException> fonctionThrowingException = x -> x + 1;
+
+		IntUnaryOperator functionThrowingRuntimeException = IntUnaryOperatorWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt(1)).is(2);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		IntUnaryOperatorWithException<IOException> fonctionThrowingException = IntUnaryOperatorWithException
+				.failing(IOException::new);
+
+		IntUnaryOperator functionThrowingRuntimeException = IntUnaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsInt(x), 1)
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		IntUnaryOperatorWithException<IOException> fonctionThrowingException = x -> x + 1;
+
+		IntUnaryOperator functionWithOptionalResult = IntUnaryOperatorWithException.lifted(fonctionThrowingException);
+
+		assertThat(functionWithOptionalResult.applyAsInt(1)).is(2);
+
+	}
+
+	@Test
+	public void sample4() {
+
+		IntUnaryOperatorWithException<IOException> fonctionThrowingException = x -> x + 1;
+
+		IntUnaryOperator functionThrowingRuntimeException = IntUnaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt(1)).is(2);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/LongBinaryOperatorSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/LongBinaryOperatorSamplesTest.java
@@ -1,0 +1,82 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.LongBinaryOperator;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.LongBinaryOperatorWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class LongBinaryOperatorSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		LongBinaryOperatorWithException<IOException> fonctionThrowingException = (x, y) -> x + y;
+
+		LongBinaryOperator functionThrowingRuntimeException = LongBinaryOperatorWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong(1, 2)).is(3L);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		LongBinaryOperatorWithException<IOException> fonctionThrowingException = LongBinaryOperatorWithException
+				.failing(IOException::new);
+
+		LongBinaryOperator functionThrowingRuntimeException = LongBinaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsLong(1, 2))
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		LongBinaryOperatorWithException<IOException> fonctionThrowingException = (x, y) -> x + y;
+
+		LongBinaryOperator functionWithOptionalResult = LongBinaryOperatorWithException
+				.lifted(fonctionThrowingException);
+
+		assertThat(functionWithOptionalResult.applyAsLong(1, 2)).is(3L);
+
+	}
+
+	@Test
+	public void sample4() {
+
+		LongBinaryOperatorWithException<IOException> fonctionThrowingException = (x, y) -> x + y;
+
+		LongBinaryOperator functionThrowingRuntimeException = LongBinaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong(1, 2)).is(3L);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/LongConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/LongConsumerSamplesTest.java
@@ -1,0 +1,122 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.LongConsumer;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.LongConsumerWithException;
+import ch.powerunit.extensions.exceptions.WrappedException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class LongConsumerSamplesTest implements TestSuite {
+
+	private class Handler<T> {
+		public T object;
+	}
+
+	@Test
+	public void sample1() {
+
+		Handler<String> handler = new Handler<>();
+
+		LongConsumerWithException<IOException> consumerThrowingException = x -> {
+			handler.object = "y" + x;
+		};
+
+		LongConsumer consumerThrowingRuntimeException = LongConsumerWithException.unchecked(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept(12);
+
+		assertThat(handler.object).is("y12");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		LongConsumerWithException<IOException> consumerThrowingException = LongConsumerWithException
+				.failing(IOException::new);
+
+		LongConsumer consumerThrowingRuntimeException = LongConsumerWithException.unchecked(consumerThrowingException);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept(12);
+		}).throwException(instanceOf(WrappedException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		Handler<String> handler = new Handler<>();
+
+		LongConsumerWithException<IOException> consumerThrowingException = x -> {
+			handler.object = "y" + x;
+		};
+
+		LongConsumer consumerThrowingRuntimeException = LongConsumerWithException.unchecked(consumerThrowingException,
+				IllegalArgumentException::new);
+
+		consumerThrowingRuntimeException.accept(12);
+
+		assertThat(handler.object).is("y12");
+
+	}
+
+	@Test
+	public void sample4() {
+
+		LongConsumerWithException<IOException> consumerThrowingException = LongConsumerWithException
+				.failing(IOException::new);
+
+		LongConsumer consumerThrowingRuntimeException = LongConsumerWithException.unchecked(consumerThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept(12);
+		}).throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample5() {
+
+		Handler<String> handler = new Handler<>();
+
+		LongConsumerWithException<IOException> consumerThrowingException1 = x -> {
+			handler.object = "y" + x;
+		};
+
+		LongConsumerWithException<IOException> consumerThrowingException2 = x -> {
+			handler.object = handler.object + "y" + x;
+		};
+
+		LongConsumer consumerThrowingRuntimeException = LongConsumerWithException
+				.unchecked(consumerThrowingException1.andThen(consumerThrowingException2));
+
+		consumerThrowingRuntimeException.accept(23);
+
+		assertThat(handler.object).is("y23y23");
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/LongFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/LongFunctionSamplesTest.java
@@ -1,0 +1,83 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.LongFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.LongFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class LongFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		LongFunctionWithException<String, IOException> fonctionThrowingException = x -> "x";
+
+		LongFunction<String> functionThrowingRuntimeException = LongFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.apply(2)).is("x");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		LongFunctionWithException<String, IOException> fonctionThrowingException = LongFunctionWithException
+				.failing(IOException::new);
+
+		LongFunction<String> functionThrowingRuntimeException = LongFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.apply(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		LongFunctionWithException<String, IOException> fonctionThrowingException = x -> "x";
+
+		LongFunction<Optional<String>> functionWithOptionalResult = LongFunctionWithException
+				.lifted(fonctionThrowingException);
+
+		assertThat(functionWithOptionalResult.apply(1)).is(optionalIs("x"));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		LongFunctionWithException<String, IOException> fonctionThrowingException = x -> "x";
+
+		LongFunction<String> functionThrowingRuntimeException = LongFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.apply(2)).is("x");
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/LongPredicateSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/LongPredicateSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.LongPredicate;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.LongPredicateWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class LongPredicateSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		LongPredicateWithException<IOException> fonctionThrowingException = x -> true;
+
+		LongPredicate functionThrowingRuntimeException = LongPredicateWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.test(2)).is(true);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		LongPredicateWithException<IOException> fonctionThrowingException = LongPredicateWithException
+				.failing(IOException::new);
+
+		LongPredicate functionThrowingRuntimeException = LongPredicateWithException.unchecked(fonctionThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.test(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		LongPredicateWithException<IOException> fonctionThrowingException = x -> true;
+
+		LongPredicate functionThrowingRuntimeException = LongPredicateWithException.unchecked(fonctionThrowingException,
+				IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.test(2)).is(true);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/LongSupplierSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/LongSupplierSamplesTest.java
@@ -1,0 +1,81 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.LongSupplier;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.LongSupplierWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class LongSupplierSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		LongSupplierWithException<IOException> supplierThrowingException = () -> 12;
+
+		LongSupplier supplierThrowingRuntimeException = LongSupplierWithException.unchecked(supplierThrowingException);
+
+		assertThat(supplierThrowingRuntimeException.getAsLong()).is(12L);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		LongSupplierWithException<IOException> supplierThrowingException = LongSupplierWithException
+				.failing(IOException::new);
+
+		LongSupplier supplierThrowingRuntimeException = LongSupplierWithException.unchecked(supplierThrowingException);
+
+		assertWhen(x -> supplierThrowingRuntimeException.getAsLong())
+				.throwException(instanceOf(RuntimeException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		LongSupplierWithException<IOException> supplierThrowingException = () -> 12;
+
+		LongSupplier supplierThrowingRuntimeException = LongSupplierWithException.unchecked(supplierThrowingException,
+				IllegalArgumentException::new);
+
+		assertThat(supplierThrowingRuntimeException.getAsLong()).is(12L);
+
+	}
+
+	@Test
+	public void sample4() {
+
+		LongSupplierWithException<IOException> supplierThrowingException = LongSupplierWithException
+				.failing(IOException::new);
+
+		LongSupplier supplierThrowingRuntimeException = LongSupplierWithException.unchecked(supplierThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen(x -> supplierThrowingRuntimeException.getAsLong())
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/LongToDoubleFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/LongToDoubleFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.LongToDoubleFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.LongToDoubleFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class LongToDoubleFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		LongToDoubleFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		LongToDoubleFunction functionThrowingRuntimeException = LongToDoubleFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble(2)).is(1d);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		LongToDoubleFunctionWithException<IOException> fonctionThrowingException = LongToDoubleFunctionWithException
+				.failing(IOException::new);
+
+		LongToDoubleFunction functionThrowingRuntimeException = LongToDoubleFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsDouble(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		LongToDoubleFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		LongToDoubleFunction functionThrowingRuntimeException = LongToDoubleFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble(2)).is(1d);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/LongToIntFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/LongToIntFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.LongToIntFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.LongToIntFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class LongToIntFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		LongToIntFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		LongToIntFunction functionThrowingRuntimeException = LongToIntFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt(2)).is(1);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		LongToIntFunctionWithException<IOException> fonctionThrowingException = LongToIntFunctionWithException
+				.failing(IOException::new);
+
+		LongToIntFunction functionThrowingRuntimeException = LongToIntFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsInt(2), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		LongToIntFunctionWithException<IOException> fonctionThrowingException = x -> 1;
+
+		LongToIntFunction functionThrowingRuntimeException = LongToIntFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt(2)).is(1);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/LongUnaryOperatorSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/LongUnaryOperatorSamplesTest.java
@@ -1,0 +1,81 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.LongUnaryOperator;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.LongUnaryOperatorWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class LongUnaryOperatorSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		LongUnaryOperatorWithException<IOException> fonctionThrowingException = x -> x + 1;
+
+		LongUnaryOperator functionThrowingRuntimeException = LongUnaryOperatorWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong(1)).is(2L);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		LongUnaryOperatorWithException<IOException> fonctionThrowingException = LongUnaryOperatorWithException
+				.failing(IOException::new);
+
+		LongUnaryOperator functionThrowingRuntimeException = LongUnaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsLong(x), 1)
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		LongUnaryOperatorWithException<IOException> fonctionThrowingException = x -> x + 1;
+
+		LongUnaryOperator functionWithOptionalResult = LongUnaryOperatorWithException.lifted(fonctionThrowingException);
+
+		assertThat(functionWithOptionalResult.applyAsLong(1)).is(2L);
+
+	}
+
+	@Test
+	public void sample4() {
+
+		LongUnaryOperatorWithException<IOException> fonctionThrowingException = x -> x + 1;
+
+		LongUnaryOperator functionThrowingRuntimeException = LongUnaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong(1)).is(2L);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ObjDoubleConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ObjDoubleConsumerSamplesTest.java
@@ -1,0 +1,165 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.ObjDoubleConsumer;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.ObjDoubleConsumerWithException;
+import ch.powerunit.extensions.exceptions.WrappedException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class ObjDoubleConsumerSamplesTest implements TestSuite {
+
+	private class Handler<T> {
+		public T object;
+	}
+
+	@Test
+	public void sample1() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjDoubleConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjDoubleConsumer<String> consumerThrowingRuntimeException = ObjDoubleConsumerWithException
+				.unchecked(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12.0");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		ObjDoubleConsumerWithException<String, IOException> consumerThrowingException = ObjDoubleConsumerWithException
+				.failing(IOException::new);
+
+		ObjDoubleConsumer<String> consumerThrowingRuntimeException = ObjDoubleConsumerWithException
+				.unchecked(consumerThrowingException);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept("y", 12);
+		}).throwException(instanceOf(WrappedException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjDoubleConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjDoubleConsumer<String> consumerThrowingRuntimeException = ObjDoubleConsumerWithException
+				.unchecked(consumerThrowingException, IllegalArgumentException::new);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12.0");
+
+	}
+
+	@Test
+	public void sample4() {
+
+		ObjDoubleConsumerWithException<String, IOException> consumerThrowingException = ObjDoubleConsumerWithException
+				.failing(IOException::new);
+
+		ObjDoubleConsumer<String> consumerThrowingRuntimeException = ObjDoubleConsumerWithException
+				.unchecked(consumerThrowingException, IllegalArgumentException::new);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept("y", 12);
+		}).throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample5() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjDoubleConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjDoubleConsumer<String> consumerThrowingRuntimeException = ObjDoubleConsumerWithException
+				.lifted(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12.0");
+
+	}
+
+	@Test
+	public void sample6() {
+
+		ObjDoubleConsumerWithException<String, IOException> consumerThrowingException = ObjDoubleConsumerWithException
+				.failing(IOException::new);
+
+		ObjDoubleConsumer<String> consumerThrowingRuntimeException = ObjDoubleConsumerWithException
+				.lifted(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+	}
+
+	@Test
+	public void sample7() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjDoubleConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjDoubleConsumer<String> consumerThrowingRuntimeException = ObjDoubleConsumerWithException
+				.ignored(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12.0");
+
+	}
+
+	@Test
+	public void sample8() {
+
+		ObjDoubleConsumerWithException<String, IOException> consumerThrowingException = ObjDoubleConsumerWithException
+				.failing(IOException::new);
+
+		ObjDoubleConsumer<String> consumerThrowingRuntimeException = ObjDoubleConsumerWithException
+				.ignored(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ObjIntConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ObjIntConsumerSamplesTest.java
@@ -1,0 +1,165 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.ObjIntConsumer;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.ObjIntConsumerWithException;
+import ch.powerunit.extensions.exceptions.WrappedException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class ObjIntConsumerSamplesTest implements TestSuite {
+
+	private class Handler<T> {
+		public T object;
+	}
+
+	@Test
+	public void sample1() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjIntConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjIntConsumer<String> consumerThrowingRuntimeException = ObjIntConsumerWithException
+				.unchecked(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		ObjIntConsumerWithException<String, IOException> consumerThrowingException = ObjIntConsumerWithException
+				.failing(IOException::new);
+
+		ObjIntConsumer<String> consumerThrowingRuntimeException = ObjIntConsumerWithException
+				.unchecked(consumerThrowingException);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept("y", 12);
+		}).throwException(instanceOf(WrappedException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjIntConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjIntConsumer<String> consumerThrowingRuntimeException = ObjIntConsumerWithException
+				.unchecked(consumerThrowingException, IllegalArgumentException::new);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12");
+
+	}
+
+	@Test
+	public void sample4() {
+
+		ObjIntConsumerWithException<String, IOException> consumerThrowingException = ObjIntConsumerWithException
+				.failing(IOException::new);
+
+		ObjIntConsumer<String> consumerThrowingRuntimeException = ObjIntConsumerWithException
+				.unchecked(consumerThrowingException, IllegalArgumentException::new);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept("y", 12);
+		}).throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample5() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjIntConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjIntConsumer<String> consumerThrowingRuntimeException = ObjIntConsumerWithException
+				.lifted(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12");
+
+	}
+
+	@Test
+	public void sample6() {
+
+		ObjIntConsumerWithException<String, IOException> consumerThrowingException = ObjIntConsumerWithException
+				.failing(IOException::new);
+
+		ObjIntConsumer<String> consumerThrowingRuntimeException = ObjIntConsumerWithException
+				.lifted(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+	}
+
+	@Test
+	public void sample7() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjIntConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjIntConsumer<String> consumerThrowingRuntimeException = ObjIntConsumerWithException
+				.ignored(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12");
+
+	}
+
+	@Test
+	public void sample8() {
+
+		ObjIntConsumerWithException<String, IOException> consumerThrowingException = ObjIntConsumerWithException
+				.failing(IOException::new);
+
+		ObjIntConsumer<String> consumerThrowingRuntimeException = ObjIntConsumerWithException
+				.ignored(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ObjLongConsumerSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ObjLongConsumerSamplesTest.java
@@ -1,0 +1,165 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.ObjLongConsumer;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.ObjLongConsumerWithException;
+import ch.powerunit.extensions.exceptions.WrappedException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class ObjLongConsumerSamplesTest implements TestSuite {
+
+	private class Handler<T> {
+		public T object;
+	}
+
+	@Test
+	public void sample1() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjLongConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjLongConsumer<String> consumerThrowingRuntimeException = ObjLongConsumerWithException
+				.unchecked(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		ObjLongConsumerWithException<String, IOException> consumerThrowingException = ObjLongConsumerWithException
+				.failing(IOException::new);
+
+		ObjLongConsumer<String> consumerThrowingRuntimeException = ObjLongConsumerWithException
+				.unchecked(consumerThrowingException);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept("y", 12);
+		}).throwException(instanceOf(WrappedException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjLongConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjLongConsumer<String> consumerThrowingRuntimeException = ObjLongConsumerWithException
+				.unchecked(consumerThrowingException, IllegalArgumentException::new);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12");
+
+	}
+
+	@Test
+	public void sample4() {
+
+		ObjLongConsumerWithException<String, IOException> consumerThrowingException = ObjLongConsumerWithException
+				.failing(IOException::new);
+
+		ObjLongConsumer<String> consumerThrowingRuntimeException = ObjLongConsumerWithException
+				.unchecked(consumerThrowingException, IllegalArgumentException::new);
+
+		assertWhen((x) -> {
+			consumerThrowingRuntimeException.accept("y", 12);
+		}).throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample5() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjLongConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjLongConsumer<String> consumerThrowingRuntimeException = ObjLongConsumerWithException
+				.lifted(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12");
+
+	}
+
+	@Test
+	public void sample6() {
+
+		ObjLongConsumerWithException<String, IOException> consumerThrowingException = ObjLongConsumerWithException
+				.failing(IOException::new);
+
+		ObjLongConsumer<String> consumerThrowingRuntimeException = ObjLongConsumerWithException
+				.lifted(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+	}
+
+	@Test
+	public void sample7() {
+
+		Handler<String> handler = new Handler<>();
+
+		ObjLongConsumerWithException<String, IOException> consumerThrowingException = (x, y) -> {
+			handler.object = "y" + x + y;
+		};
+
+		ObjLongConsumer<String> consumerThrowingRuntimeException = ObjLongConsumerWithException
+				.ignored(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+		assertThat(handler.object).is("yy12");
+
+	}
+
+	@Test
+	public void sample8() {
+
+		ObjLongConsumerWithException<String, IOException> consumerThrowingException = ObjLongConsumerWithException
+				.failing(IOException::new);
+
+		ObjLongConsumer<String> consumerThrowingRuntimeException = ObjLongConsumerWithException
+				.ignored(consumerThrowingException);
+
+		consumerThrowingRuntimeException.accept("y", 12);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/PredicateSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/PredicateSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.Predicate;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.PredicateWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class PredicateSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		PredicateWithException<String, IOException> fonctionThrowingException = x -> true;
+
+		Predicate<String> functionThrowingRuntimeException = PredicateWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.test("x")).is(true);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		PredicateWithException<String, IOException> fonctionThrowingException = PredicateWithException
+				.failing(IOException::new);
+
+		Predicate<String> functionThrowingRuntimeException = PredicateWithException.unchecked(fonctionThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.test(x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		PredicateWithException<String, IOException> fonctionThrowingException = x -> true;
+
+		Predicate<String> functionThrowingRuntimeException = PredicateWithException.unchecked(fonctionThrowingException,
+				IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.test("x")).is(true);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/RunnableSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/RunnableSamplesTest.java
@@ -1,0 +1,88 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.RunnableWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class RunnableSamplesTest implements TestSuite {
+
+	private class Handler<T> {
+		public T object;
+	}
+
+	@Test
+	public void sample1() {
+
+		Handler<String> data = new Handler<>();
+
+		RunnableWithException<IOException> supplierThrowingException = () -> data.object = "12";
+
+		Runnable supplierThrowingRuntimeException = RunnableWithException.unchecked(supplierThrowingException);
+
+		supplierThrowingRuntimeException.run();
+
+		assertThat(data.object).is("12");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		RunnableWithException<IOException> supplierThrowingException = RunnableWithException.failing(IOException::new);
+
+		Runnable supplierThrowingRuntimeException = RunnableWithException.unchecked(supplierThrowingException);
+
+		assertWhen(x -> supplierThrowingRuntimeException.run()).throwException(instanceOf(RuntimeException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		Handler<String> data = new Handler<>();
+
+		RunnableWithException<IOException> supplierThrowingException = () -> data.object = "12";
+
+		Runnable supplierThrowingRuntimeException = RunnableWithException.unchecked(supplierThrowingException,
+				IllegalArgumentException::new);
+
+		supplierThrowingRuntimeException.run();
+		assertThat(data.object).is("12");
+
+	}
+
+	@Test
+	public void sample4() {
+
+		RunnableWithException<IOException> supplierThrowingException = RunnableWithException.failing(IOException::new);
+
+		Runnable supplierThrowingRuntimeException = RunnableWithException.unchecked(supplierThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen(x -> supplierThrowingRuntimeException.run())
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/SupplierSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/SupplierSamplesTest.java
@@ -1,0 +1,80 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.SupplierWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class SupplierSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		SupplierWithException<String, IOException> supplierThrowingException = () -> "12";
+
+		Supplier<String> supplierThrowingRuntimeException = SupplierWithException.unchecked(supplierThrowingException);
+
+		assertThat(supplierThrowingRuntimeException.get()).is("12");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		SupplierWithException<String, IOException> supplierThrowingException = SupplierWithException
+				.failing(IOException::new);
+
+		Supplier<String> supplierThrowingRuntimeException = SupplierWithException.unchecked(supplierThrowingException);
+
+		assertWhen(x -> supplierThrowingRuntimeException.get()).throwException(instanceOf(RuntimeException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		SupplierWithException<String, IOException> supplierThrowingException = () -> "12";
+
+		Supplier<String> supplierThrowingRuntimeException = SupplierWithException.unchecked(supplierThrowingException,
+				IllegalArgumentException::new);
+
+		assertThat(supplierThrowingRuntimeException.get()).is("12");
+
+	}
+
+	@Test
+	public void sample4() {
+
+		SupplierWithException<String, IOException> supplierThrowingException = SupplierWithException
+				.failing(IOException::new);
+
+		Supplier<String> supplierThrowingRuntimeException = SupplierWithException.unchecked(supplierThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen(x -> supplierThrowingRuntimeException.get())
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ToDoubleBiFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ToDoubleBiFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.ToDoubleBiFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.ToDoubleBiFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class ToDoubleBiFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		ToDoubleBiFunctionWithException<String, String, IOException> fonctionThrowingException = (x, y) -> 1;
+
+		ToDoubleBiFunction<String, String> functionThrowingRuntimeException = ToDoubleBiFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble("x", "y")).is(1d);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		ToDoubleBiFunctionWithException<String, String, IOException> fonctionThrowingException = ToDoubleBiFunctionWithException
+				.failing(IOException::new);
+
+		ToDoubleBiFunction<String, String> functionThrowingRuntimeException = ToDoubleBiFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsDouble(x, x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		ToDoubleBiFunctionWithException<String, String, IOException> fonctionThrowingException = (x, y) -> 1;
+
+		ToDoubleBiFunction<String, String> functionThrowingRuntimeException = ToDoubleBiFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble("x", "y")).is(1d);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ToDoubleFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ToDoubleFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.ToDoubleFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.ToDoubleFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class ToDoubleFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		ToDoubleFunctionWithException<String, IOException> fonctionThrowingException = x -> 1;
+
+		ToDoubleFunction<String> functionThrowingRuntimeException = ToDoubleFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble("x")).is(1d);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		ToDoubleFunctionWithException<String, IOException> fonctionThrowingException = ToDoubleFunctionWithException
+				.failing(IOException::new);
+
+		ToDoubleFunction<String> functionThrowingRuntimeException = ToDoubleFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsDouble(x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		ToDoubleFunctionWithException<String, IOException> fonctionThrowingException = x -> 1;
+
+		ToDoubleFunction<String> functionThrowingRuntimeException = ToDoubleFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsDouble("x")).is(1d);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ToIntBiFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ToIntBiFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.ToIntBiFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.ToIntBiFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class ToIntBiFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		ToIntBiFunctionWithException<String, String, IOException> fonctionThrowingException = (x, y) -> 1;
+
+		ToIntBiFunction<String, String> functionThrowingRuntimeException = ToIntBiFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt("x", "y")).is(1);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		ToIntBiFunctionWithException<String, String, IOException> fonctionThrowingException = ToIntBiFunctionWithException
+				.failing(IOException::new);
+
+		ToIntBiFunction<String, String> functionThrowingRuntimeException = ToIntBiFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsInt(x, x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		ToIntBiFunctionWithException<String, String, IOException> fonctionThrowingException = (x, y) -> 1;
+
+		ToIntBiFunction<String, String> functionThrowingRuntimeException = ToIntBiFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt("x", "y")).is(1);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ToIntFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ToIntFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.ToIntFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.ToIntFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class ToIntFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		ToIntFunctionWithException<String, IOException> fonctionThrowingException = x -> 1;
+
+		ToIntFunction<String> functionThrowingRuntimeException = ToIntFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt("x")).is(1);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		ToIntFunctionWithException<String, IOException> fonctionThrowingException = ToIntFunctionWithException
+				.failing(IOException::new);
+
+		ToIntFunction<String> functionThrowingRuntimeException = ToIntFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsInt(x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		ToIntFunctionWithException<String, IOException> fonctionThrowingException = x -> 1;
+
+		ToIntFunction<String> functionThrowingRuntimeException = ToIntFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsInt("x")).is(1);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ToLongBiFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ToLongBiFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.ToLongBiFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.ToLongBiFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class ToLongBiFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		ToLongBiFunctionWithException<String, String, IOException> fonctionThrowingException = (x, y) -> 1;
+
+		ToLongBiFunction<String, String> functionThrowingRuntimeException = ToLongBiFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong("x", "y")).is(1L);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		ToLongBiFunctionWithException<String, String, IOException> fonctionThrowingException = ToLongBiFunctionWithException
+				.failing(IOException::new);
+
+		ToLongBiFunction<String, String> functionThrowingRuntimeException = ToLongBiFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsLong(x, x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		ToLongBiFunctionWithException<String, String, IOException> fonctionThrowingException = (x, y) -> 1;
+
+		ToLongBiFunction<String, String> functionThrowingRuntimeException = ToLongBiFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong("x", "y")).is(1L);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/ToLongFunctionSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/ToLongFunctionSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.function.ToLongFunction;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.ToLongFunctionWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class ToLongFunctionSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		ToLongFunctionWithException<String, IOException> fonctionThrowingException = x -> 1;
+
+		ToLongFunction<String> functionThrowingRuntimeException = ToLongFunctionWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong("x")).is(1L);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		ToLongFunctionWithException<String, IOException> fonctionThrowingException = ToLongFunctionWithException
+				.failing(IOException::new);
+
+		ToLongFunction<String> functionThrowingRuntimeException = ToLongFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.applyAsLong(x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		ToLongFunctionWithException<String, IOException> fonctionThrowingException = x -> 1;
+
+		ToLongFunction<String> functionThrowingRuntimeException = ToLongFunctionWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.applyAsLong("x")).is(1L);
+
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/UnaryOperatorSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/UnaryOperatorSamplesTest.java
@@ -1,0 +1,84 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.UnaryOperatorWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a test
+public class UnaryOperatorSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		UnaryOperatorWithException<String, IOException> fonctionThrowingException = x -> x;
+
+		UnaryOperator<String> functionThrowingRuntimeException = UnaryOperatorWithException
+				.unchecked(fonctionThrowingException);
+
+		assertThatFunction(functionThrowingRuntimeException, "x").is("x");
+
+	}
+
+	@Test
+	public void sample2() {
+
+		UnaryOperatorWithException<String, IOException> fonctionThrowingException = UnaryOperatorWithException
+				.failing(IOException::new);
+
+		UnaryOperator<String> functionThrowingRuntimeException = UnaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.apply(x), "x")
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample3() {
+
+		UnaryOperatorWithException<String, IOException> fonctionThrowingException = x -> x;
+
+		Function<String, Optional<String>> functionWithOptionalResult = UnaryOperatorWithException
+				.lifted(fonctionThrowingException);
+
+		assertThatFunction(functionWithOptionalResult, "x").is(optionalIs("x"));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		UnaryOperatorWithException<String, IOException> fonctionThrowingException = x -> x;
+
+		UnaryOperator<String> functionThrowingRuntimeException = UnaryOperatorWithException
+				.unchecked(fonctionThrowingException, IllegalArgumentException::new);
+
+		assertThatFunction(functionThrowingRuntimeException, "x").is("x");
+
+	}
+
+}


### PR DESCRIPTION
### Review each classes and add general information on top
- [x] BiConsumerWithException
- [x] BiFunctionWithException
- [x] BinaryOperatorWithException
- [x] BiPredicateWithException
- [x] BooleanSupplierWithException
- [x] ConsumerWithException
- [x] DoubleBinaryOperatorWithException
- [x] DoubleConsumerWithException
- [x] DoubleFunctionWithException
- [x] DoublePredicateWithException
- [x] DoubleSupplierWithException
- [x] DoubleToIntFunctionWithException
- [x] DoubleToLongFunctionWithException
- [x] DoubleUnaryOperatorWithException
- [x] FunctionWithException
- [x] IntBinaryOperatorWithException
- [x] IntConsumerWithException
- [x] IntFunctionWithException
- [x] IntPredicateWithException
- [x] IntSupplierWithException
- [x] IntToDoubleFunctionWithException
- [x] IntToLongFunctionWithException
- [x] IntUnaryOperatorWithException
- [x] LongBinaryOperatorWithException
- [x] LongConsumerWithException
- [x] LongFunctionWithException
- [x] LongPredicateWithException
- [x] LongSupplierWithException
- [x] LongToDoubleFunctionWithException
- [x] LongToIntFunctionWithException
- [x] LongUnaryOperatorWithException
- [x] ObjDoubleConsumerWithException
- [x] ObjIntConsumerWithException
- [x] ObjLongConsumerWithException
- [x] package-info
- [x] PredicateWithException
- [x] RunnableWithException
- [x] SupplierWithException
- [x] ToDoubleBiFunctionWithException
- [x] ToDoubleFunctionWithException
- [x] ToIntBiFunctionWithException
- [x] ToIntFunctionWithException
- [x] ToLongBiFunctionWithException
- [x] ToLongFunctionWithException
- [x] UnaryOperatorWithException
