### PR TITLE
Add PathMatcher functional interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The following classes are provided:
 | `ObjDoubleConsumer<T>`          | `ObjDoubleConsumerWithException<T,E>`    | `ObjDoubleConsumer<T>`    | `ObjDoubleConsumer<T>`           | `ObjDoubleConsumer<T>`   | `Function<T,Double,CompletionStage<Void>>` |
 | `ObjIntConsumer<T>`             | `ObjIntConsumerWithException<T,E>`       | `ObjIntConsumer<T>`       | `ObjIntConsumer<T>`              | `ObjIntConsumer<T>`      | `Function<T,Integer,CompletionStage<Void>>` |
 | `ObjLongConsumer<T>`            | `ObjLongConsumerWithException<T,E>`      | `ObjLongConsumer<T>`      | `ObjLongConsumer<T>`             | `ObjLongConsumer<T>`     | `Function<T,Long,CompletionStage<Void>>` |
+| `PathMatcher`                  | `PathMatcherWithException<E>`            | `PathMatcher`            | `PathMatcher`                   | `PathMatcher`           | N/A
 | `Predicate<T>`                  | `PredicateWithException<T,E>`            | `Predicate<T>`            | `Predicate<T>`                   | `Predicate<T>`           | N/A
 | `Runnable`                      | `RunnableWithException<E>`               | `Runnable`                | `Runnable`                       | `Runnable`               | `Supplier<CompletionStage<Void>>`|
 | `Supplier<T>`                   | `SupplierWithException<T,E>`             | `Supplier<T>`             | `Supplier<Optional<T>>`          | `Supplier<T>`            | `Supplier<CompletionStage<T>>` |

--- a/src/main/java/ch/powerunit/extensions/exceptions/PathMatcherWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/PathMatcherWithException.java
@@ -1,0 +1,259 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions;
+
+import static ch.powerunit.extensions.exceptions.Constants.EXCEPTIONMAPPER_CANT_BE_NULL;
+import static ch.powerunit.extensions.exceptions.Constants.PREDICATE_CANT_BE_NULL;
+import static java.util.Objects.requireNonNull;
+
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * An interface that is implemented by objects that perform match operations on
+ * paths and may throw an exception.
+ * <h3>General contract</h3>
+ * <ul>
+ * <li><b>{@link #matches(Path) boolean matches(Path path) throws
+ * E}</b>&nbsp;-&nbsp;The functional method.</li>
+ * <li><b>uncheck</b>&nbsp;-&nbsp;Return a {@code PathMatcher<T>}</li>
+ * <li><b>lift</b>&nbsp;-&nbsp;Return a {@code PathMatcher<T>}</li>
+ * <li><b>ignore</b>&nbsp;-&nbsp;Return a {@code PathMatcher<T>}</li>
+ * </ul>
+ *
+ * @see PathMatcher
+ * @param <E>
+ *            the type of the potential exception of the function
+ * @since 1.1.0
+ */
+@FunctionalInterface
+public interface PathMatcherWithException<E extends Exception>
+		extends PrimitiveReturnExceptionHandlerSupport<PathMatcher> {
+
+	/**
+	 * Tells if given path matches this matcher's pattern.
+	 *
+	 * @param path
+	 *            the path to match
+	 *
+	 * @return {@code true} if, and only if, the path matches this matcher's pattern
+	 * @throws E
+	 *             any exception
+	 * @see PathMatcher#matches(Path)
+	 */
+	boolean matches(Path path) throws E;
+
+	@Override
+	default PathMatcher uncheckOrIgnore(boolean uncheck) {
+		return value -> {
+			try {
+				return matches(value);
+			} catch (Exception e) {
+				PrimitiveReturnExceptionHandlerSupport.handleException(uncheck, e, exceptionMapper());
+				return false;
+			}
+		};
+	}
+
+	/**
+	 * Returns a composed PathMatcher that represents a short-circuiting logical AND
+	 * of this PathMatcher and another. When evaluating the composed predicate, if
+	 * this predicate is {@code false}, then the {@code other} predicate is not
+	 * evaluated.
+	 *
+	 * <p>
+	 * Any exceptions thrown during evaluation of either PathMatcher are relayed to
+	 * the caller; if evaluation of this predicate throws an exception, the
+	 * {@code other} PathMatcher will not be evaluated.
+	 *
+	 * @param other
+	 *            a PathMatcher that will be logically-ANDed with this predicate
+	 * @return a composed PathMatcher that represents the short-circuiting logical
+	 *         AND of this PathMatcher and the {@code other} PathMatcher
+	 * @throws NullPointerException
+	 *             if other is null
+	 * @see #or(PathMatcherWithException)
+	 * @see #negate()
+	 */
+	default PathMatcherWithException<E> and(PathMatcherWithException<? extends E> other) {
+		requireNonNull(other);
+		return t -> matches(t) && other.matches(t);
+	}
+
+	/**
+	 * Returns a PathMatcher that represents the logical negation of this
+	 * PathMatcher.
+	 *
+	 * @return a PathMatcher that represents the logical negation of this
+	 *         PathMatcher
+	 * @see #and(PathMatcherWithException)
+	 * @see #or(PathMatcherWithException)
+	 */
+	default PathMatcherWithException<E> negate() {
+		return t -> !matches(t);
+	}
+
+	/**
+	 * Negate a {@code PredicateWithException}.
+	 *
+	 * @param predicate
+	 *            to be negate
+	 * @param <E>
+	 *            the type of the potential exception
+	 * @return the negated PathMatcher
+	 * @see #negate()
+	 * @throws NullPointerException
+	 *             if predicate is null
+	 */
+	static <E extends Exception> PathMatcherWithException<E> negate(PathMatcherWithException<E> predicate) {
+		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).negate();
+	}
+
+	/**
+	 * Returns a composed PathMatcher that represents a short-circuiting logical OR
+	 * of this PathMatcher and another. When evaluating the composed PathMatcher, if
+	 * this PathMatcher is {@code true}, then the {@code other} predicate is not
+	 * evaluated.
+	 *
+	 * <p>
+	 * Any exceptions thrown during evaluation of either PathMatcher are relayed to
+	 * the caller; if evaluation of this PathMatcher throws an exception, the
+	 * {@code other} PathMatcher will not be evaluated.
+	 *
+	 * @param other
+	 *            a PathMatcher that will be logically-ORed with this predicate
+	 * @return a composed PathMatcher that represents the short-circuiting logical
+	 *         OR of this predicate and the {@code other} PathMatcher
+	 * @throws NullPointerException
+	 *             if other is null
+	 * @see #and(PathMatcherWithException)
+	 * @see #negate()
+	 */
+	default PathMatcherWithException<E> or(PathMatcherWithException<? extends E> other) {
+		requireNonNull(other);
+		return t -> matches(t) || other.matches(t);
+	}
+
+	/**
+	 * Returns a PathMatcher that always throw exception.
+	 *
+	 * @param exceptionBuilder
+	 *            the supplier to create the exception
+	 * @param <E>
+	 *            the type of the exception
+	 * @return a PathMatcher that always throw exception
+	 */
+	static <E extends Exception> PathMatcherWithException<E> failing(Supplier<E> exceptionBuilder) {
+		return t -> {
+			throw exceptionBuilder.get();
+		};
+	}
+
+	/**
+	 * Converts a {@code PathMatcherWithException} to a {@code PathMatcher} that
+	 * wraps exception to {@code RuntimeException}.
+	 *
+	 * @param predicate
+	 *            to be unchecked
+	 * @param <E>
+	 *            the type of the potential exception
+	 * @return the unchecked PathMatcher
+	 * @see #uncheck()
+	 * @see #unchecked(PathMatcherWithException, Function)
+	 * @throws NullPointerException
+	 *             if predicate is null
+	 */
+	static <E extends Exception> PathMatcher unchecked(PathMatcherWithException<E> predicate) {
+		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).uncheck();
+	}
+
+	/**
+	 * Converts a {@code PathMatcherWithException} to a {@code PathMatcher} that
+	 * wraps exception to {@code RuntimeException} by using the provided mapping
+	 * function.
+	 *
+	 * @param predicate
+	 *            the be unchecked
+	 * @param exceptionMapper
+	 *            a function to convert the exception to the runtime exception.
+	 * @param <E>
+	 *            the type of the potential exception
+	 * @return the unchecked PathMatcher
+	 * @see #uncheck()
+	 * @see #unchecked(PathMatcherWithException)
+	 * @throws NullPointerException
+	 *             if predicate or exceptionMapper is null
+	 */
+	static <E extends Exception> PathMatcher unchecked(PathMatcherWithException<E> predicate,
+			Function<Exception, RuntimeException> exceptionMapper) {
+		requireNonNull(predicate, PREDICATE_CANT_BE_NULL);
+		requireNonNull(exceptionMapper, EXCEPTIONMAPPER_CANT_BE_NULL);
+		return new PathMatcherWithException<E>() {
+
+			@Override
+			public boolean matches(Path t) throws E {
+				return predicate.matches(t);
+			}
+
+			@Override
+			public Function<Exception, RuntimeException> exceptionMapper() {
+				return exceptionMapper;
+			}
+
+		}.uncheck();
+	}
+
+	/**
+	 * Converts a {@code PathMatcherWithException} to a lifted {@code PathMatcher}
+	 * returning {@code false} in case of exception.
+	 *
+	 * @param predicate
+	 *            to be lifted
+	 * @param <E>
+	 *            the type of the potential exception
+	 * @return the lifted PathMatcher
+	 * @see #lift()
+	 * @throws NullPointerException
+	 *             if predicate is null
+	 */
+	static <E extends Exception> PathMatcher lifted(PathMatcherWithException<E> predicate) {
+		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).lift();
+	}
+
+	/**
+	 * Converts a {@code PathMatcherWithException} to a lifted {@code PathMatcher}
+	 * returning {@code false} in case of exception.
+	 *
+	 * @param predicate
+	 *            to be lifted
+	 * @param <E>
+	 *            the type of the potential exception
+	 * @return the lifted PathMatcher
+	 * @see #ignore()
+	 * @throws NullPointerException
+	 *             if predicate is null
+	 */
+	static <E extends Exception> PathMatcher ignored(PathMatcherWithException<E> predicate) {
+		return requireNonNull(predicate, PREDICATE_CANT_BE_NULL).ignore();
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/PathMatcherWithExceptionTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/PathMatcherWithExceptionTest.java
@@ -1,0 +1,151 @@
+/**
+ * Powerunit - A JDK1.8 matches framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions;
+
+import java.nio.file.Paths;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a matches
+public class PathMatcherWithExceptionTest implements TestSuite {
+
+	@Test
+	public void matchesFailing() {
+		assertWhen((x) -> PathMatcherWithException.failing(Exception::new).matches(x), Paths.get("."))
+				.throwException(instanceOf(Exception.class));
+	}
+
+	@Test
+	public void matchesAnd1() throws Exception {
+		PathMatcherWithException<Exception> fct1 = x -> true;
+		PathMatcherWithException<Exception> fct2 = x -> false;
+		assertThat(fct1.and(fct2).matches(Paths.get("."))).is(false);
+	}
+
+	@Test
+	public void matchesAnd2() throws Exception {
+		PathMatcherWithException<Exception> fct1 = x -> false;
+		PathMatcherWithException<Exception> fct2 = x -> true;
+		assertThat(fct1.and(fct2).matches(Paths.get("."))).is(false);
+	}
+
+	@Test
+	public void matchesAnd3() throws Exception {
+		PathMatcherWithException<Exception> fct1 = x -> false;
+		PathMatcherWithException<Exception> fct2 = x -> false;
+		assertThat(fct1.and(fct2).matches(Paths.get("."))).is(false);
+	}
+
+	@Test
+	public void matchesAnd4() throws Exception {
+		PathMatcherWithException<Exception> fct1 = x -> true;
+		PathMatcherWithException<Exception> fct2 = x -> true;
+		assertThat(fct1.and(fct2).matches(Paths.get("."))).is(true);
+	}
+
+	@Test
+	public void matchesOr1() throws Exception {
+		PathMatcherWithException<Exception> fct1 = x -> true;
+		PathMatcherWithException<Exception> fct2 = x -> false;
+		assertThat(fct1.or(fct2).matches(Paths.get("."))).is(true);
+	}
+
+	@Test
+	public void matchesOr2() throws Exception {
+		PathMatcherWithException<Exception> fct1 = x -> true;
+		PathMatcherWithException<Exception> fct2 = x -> true;
+		assertThat(fct1.or(fct2).matches(Paths.get("."))).is(true);
+	}
+
+	@Test
+	public void matchesOr3() throws Exception {
+		PathMatcherWithException<Exception> fct1 = x -> false;
+		PathMatcherWithException<Exception> fct2 = x -> true;
+		assertThat(fct1.or(fct2).matches(Paths.get("."))).is(true);
+	}
+
+	@Test
+	public void matchesOr4() throws Exception {
+		PathMatcherWithException<Exception> fct1 = x -> false;
+		PathMatcherWithException<Exception> fct2 = x -> false;
+		assertThat(fct1.or(fct2).matches(Paths.get("."))).is(false);
+	}
+
+	@Test
+	public void matchesNegate1() throws Exception {
+		assertThat(PathMatcherWithException.negate(x -> true).matches(Paths.get("."))).is(false);
+	}
+
+	@Test
+	public void matchesNegate2() throws Exception {
+		assertThat(PathMatcherWithException.negate(x -> false).matches(Paths.get("."))).is(true);
+	}
+
+	@Test
+	public void matchesCheckedNoException() {
+		assertThat(PathMatcherWithException.unchecked(x -> true).matches(Paths.get("."))).is(true);
+	}
+
+	@Test
+	public void matchesCheckedException() {
+		assertWhen((x) -> PathMatcherWithException.unchecked(y -> {
+			throw new Exception();
+		}).matches(Paths.get("."))).throwException(instanceOf(WrappedException.class));
+	}
+
+	@Test
+	public void matchesCheckedNoExceptionHandler() {
+		assertThat(PathMatcherWithException.unchecked(x -> true, RuntimeException::new).matches(Paths.get(".")))
+				.is(true);
+	}
+
+	@Test
+	public void matchesCheckedExceptionHandler() {
+		assertWhen((x) -> PathMatcherWithException.unchecked(y -> {
+			throw new Exception();
+		}, RuntimeException::new).matches(Paths.get("."))).throwException(instanceOf(RuntimeException.class));
+	}
+
+	@Test
+	public void matchesLiftedNoException() {
+		assertThat(PathMatcherWithException.lifted(x -> true).matches(Paths.get("."))).is(true);
+	}
+
+	@Test
+	public void matchesLiftedException() {
+		assertThat(PathMatcherWithException.lifted(y -> {
+			throw new Exception();
+		}).matches(Paths.get("."))).is(false);
+	}
+
+	@Test
+	public void matchesIgnoredNoException() {
+		assertThat(PathMatcherWithException.ignored(x -> true).matches(Paths.get("."))).is(true);
+	}
+
+	@Test
+	public void matchesIgnoredException() {
+		assertThat(PathMatcherWithException.ignored(y -> {
+			throw new Exception();
+		}).matches(Paths.get("."))).is(false);
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/exceptions/samples/PathMatcherSamplesTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/samples/PathMatcherSamplesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Powerunit - A JDK1.8 matches framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.exceptions.samples;
+
+import java.io.IOException;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.exceptions.PathMatcherWithException;
+
+@SuppressWarnings("squid:S2187") // Sonar doesn't under that it is really a matches
+public class PathMatcherSamplesTest implements TestSuite {
+
+	@Test
+	public void sample1() {
+
+		PathMatcherWithException<IOException> fonctionThrowingException = x -> true;
+
+		PathMatcher functionThrowingRuntimeException = PathMatcherWithException.unchecked(fonctionThrowingException);
+
+		assertThat(functionThrowingRuntimeException.matches(Paths.get("."))).is(true);
+
+	}
+
+	@Test
+	public void sample2() {
+
+		PathMatcherWithException<IOException> fonctionThrowingException = PathMatcherWithException
+				.failing(IOException::new);
+
+		PathMatcher functionThrowingRuntimeException = PathMatcherWithException.unchecked(fonctionThrowingException,
+				IllegalArgumentException::new);
+
+		assertWhen(x -> functionThrowingRuntimeException.matches(Paths.get(".")))
+				.throwException(instanceOf(IllegalArgumentException.class));
+
+	}
+
+	@Test
+	public void sample4() {
+
+		PathMatcherWithException<IOException> fonctionThrowingException = x -> true;
+
+		PathMatcher functionThrowingRuntimeException = PathMatcherWithException.unchecked(fonctionThrowingException,
+				IllegalArgumentException::new);
+
+		assertThat(functionThrowingRuntimeException.matches(Paths.get("."))).is(true);
+
+	}
+
+}


### PR DESCRIPTION
### Links

| Name           |  References                             |
| -------------- | --------------------------------------- |
| Related issues | #28  |
| Related PR     |                                         |

### Summary

Add PathMatcher functional interface

### Description

Add PathMatcher functional interface based on the `Predicate` one.
