### PR TITLE
Add andThen to RunnableWithException interface

### DIFF
--- a/src/main/java/ch/powerunit/extensions/exceptions/RunnableWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/RunnableWithException.java
@@ -95,6 +95,29 @@ public interface RunnableWithException<E extends Exception>
 	}
 
 	/**
+	 * Returns a composed {@code RunnableWithException} that performs, in sequence,
+	 * this operation followed by the {@code after} operation. If performing either
+	 * operation throws an exception, it is relayed to the caller of the composed
+	 * operation. If performing this operation throws an exception, the
+	 * {@code after} operation will not be performed.
+	 *
+	 * @param after
+	 *            the operation to perform after this operation
+	 * @return a composed {@code RunnableWithException} that performs in sequence
+	 *         this operation followed by the {@code after} operation
+	 * @throws NullPointerException
+	 *             if {@code after} is null
+	 * @since 1.2.0
+	 */
+	default RunnableWithException<E> andThen(RunnableWithException<? extends E> after) {
+		requireNonNull(after);
+		return () -> {
+			run();
+			after.run();
+		};
+	}
+
+	/**
 	 * Returns an operation that always throw exception.
 	 *
 	 * @param exceptionBuilder

--- a/src/test/java/ch/powerunit/extensions/exceptions/RunnableWithExceptionTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/RunnableWithExceptionTest.java
@@ -34,13 +34,22 @@ public class RunnableWithExceptionTest implements TestSuite {
 	}
 
 	@Test
-	public void testandThen() throws Exception {
+	public void testandThen1() throws Exception {
 		RunnableWithException<Exception> fct1 = () -> {
 		};
 		RunnableWithException<Exception> fct2 = () -> {
 			throw new Exception();
 		};
 		assertWhen((x) -> fct1.andThen(fct2).run()).throwException(instanceOf(Exception.class));
+	}
+	
+	@Test
+	public void testandThen2() throws Exception {
+		RunnableWithException<Exception> fct1 = () -> {
+		};
+		RunnableWithException<Exception> fct2 = () -> {
+		};
+		fct1.andThen(fct2).run();
 	}
 
 	@Test

--- a/src/test/java/ch/powerunit/extensions/exceptions/RunnableWithExceptionTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/RunnableWithExceptionTest.java
@@ -34,6 +34,16 @@ public class RunnableWithExceptionTest implements TestSuite {
 	}
 
 	@Test
+	public void testandThen() throws Exception {
+		RunnableWithException<Exception> fct1 = () -> {
+		};
+		RunnableWithException<Exception> fct2 = () -> {
+			throw new Exception();
+		};
+		assertWhen((x) -> fct1.andThen(fct2).run()).throwException(instanceOf(Exception.class));
+	}
+
+	@Test
 	public void testCheckedNoException() {
 		RunnableWithException.unchecked(() -> {
 		}).run();


### PR DESCRIPTION
### Links

| Name           |  References                             |
| -------------- | --------------------------------------- |
| Related issues | #39 |
| Related PR     |     |

### Summary

Add andThen to RunnableWithException to chain them.

### Description

Add andThen to RunnableWithException to chain them.

