### PR TITLE
Add asFunction to RunnableWithException

### DIFF
--- a/src/main/java/ch/powerunit/extensions/exceptions/RunnableWithException.java
+++ b/src/main/java/ch/powerunit/extensions/exceptions/RunnableWithException.java
@@ -235,4 +235,29 @@ public interface RunnableWithException<E extends Exception>
 		return requireNonNull(operation, OPERATION_CANT_BE_NULL).stage();
 	}
 
+	/**
+	 * Converts a {@code RunnableWithException} to a {@code FunctionWithException}
+	 * returning {@code null} and ignoring input.
+	 *
+	 * @param operation
+	 *            to be converted
+	 * @param <T>
+	 *            the type of the input to the operation
+	 * @param <R>
+	 *            the type of the return value
+	 * @param <E>
+	 *            the type of the potential exception
+	 * @return the function
+	 * @throws NullPointerException
+	 *             if operation is null
+	 * @since 1.2.0
+	 */
+	static <T, R, E extends Exception> FunctionWithException<T, R, E> asFunction(RunnableWithException<E> operation) {
+		requireNonNull(operation, OPERATION_CANT_BE_NULL);
+		return t -> {
+			operation.run();
+			return null;
+		};
+	}
+
 }

--- a/src/test/java/ch/powerunit/extensions/exceptions/RunnableWithExceptionTest.java
+++ b/src/test/java/ch/powerunit/extensions/exceptions/RunnableWithExceptionTest.java
@@ -42,7 +42,7 @@ public class RunnableWithExceptionTest implements TestSuite {
 		};
 		assertWhen((x) -> fct1.andThen(fct2).run()).throwException(instanceOf(Exception.class));
 	}
-	
+
 	@Test
 	public void testandThen2() throws Exception {
 		RunnableWithException<Exception> fct1 = () -> {
@@ -109,5 +109,18 @@ public class RunnableWithExceptionTest implements TestSuite {
 		assertWhen((x) -> RunnableWithException.staged(() -> {
 			throw new Exception();
 		}).get().toCompletableFuture().join()).throwException(instanceOf(CompletionException.class));
+	}
+
+	@Test
+	public void testAsFunctionNoException() throws Exception {
+		assertThat(RunnableWithException.asFunction(() -> {
+		}).apply("2")).isNull();
+	}
+
+	@Test
+	public void testAsFunctionException() {
+		assertWhen((x) -> RunnableWithException.asFunction(() -> {
+			throw new Exception();
+		}).apply("2")).throwException(instanceOf(Exception.class));
 	}
 }


### PR DESCRIPTION
### Links

| Name           |  References                             |
| -------------- | --------------------------------------- |
| Related issues | #41  |
| Related PR     |                                         |

### Summary

Add `asFunction` to `RunnableWithException` simplify exchange between interface format.
